### PR TITLE
.vim ディレクトリを削除

### DIFF
--- a/.vim/coc-settings.json
+++ b/.vim/coc-settings.json
@@ -1,5 +1,0 @@
-{
-  "deno.enable": true,
-  "deno.lint": true,
-  "deno.unstable": true
-}


### PR DESCRIPTION
現在は coc.nvim を使用していないため、その設定のみしか置かれていない `.vim` ディレクトリを削除する