### PR TITLE
GCの実装の改善（三色抽象化を導入）

### DIFF
--- a/examples/manual_gc.ajs
+++ b/examples/manual_gc.ajs
@@ -1,0 +1,16 @@
+proc print_repeated_str(src: str, count: i32) {
+    println_str(str_slice(src, 0, count));
+    if count != 0 {
+        print_repeated_str(src, count - 1)
+    } else {
+        ()
+    }
+}
+
+proc main() {
+    print_repeated_str("Hoge", 4);
+    gc_start();
+    print_repeated_str("Fuga", 4);
+    gc_start();
+    print_repeated_str("Piyo", 4)
+}

--- a/src/c_src_printer.ts
+++ b/src/c_src_printer.ts
@@ -123,7 +123,7 @@ const printProcBodyInst = async (file: Deno.FsFile, encoder: TextEncoder, inst: 
       break;
     case "str.make_static":
       // TODO: collect_root_func を設定
-      line = `  static AjisaiString static_str${inst.id} = { .obj_header = { .tag = AJISAI_OBJ_STR_STATIC }, .len = ${inst.len}, .value = ${inst.value} };\n  static_str${inst.id}.obj_header.type_info = ajisai_str_type_info();\n`;
+      line = `  static AjisaiString static_str${inst.id} = { .obj_header = { .tag = AJISAI_OBJ_STR }, .len = ${inst.len}, .value = ${inst.value} };\n  static_str${inst.id}.obj_header.type_info = ajisai_str_type_info();\n`;
       break;
     default:
       break;


### PR DESCRIPTION
生きているオブジェクトの探索を待機しているオブジェクト（灰色オブジェクト）を繰り返しキューに加えてしまうことで無限ループに陥るバグがあったので、真面目に三色抽象化を考えた処理をGCのアルゴリズムに加えた。色情報をオブジェクトに記録する方法として、`AjisaiObject` の `tag` メンバの上位ビットをメタデータの領域として利用することとした。

また、`AjisaiObjTag` では `AJISAI_OBJ_STR_STATIC` と `AJISAI_OBJ_STR_HEAP` を定義していたが、ヒープオブジェクトであるかそうでないかは、のちに関数オブジェクト等でも区別する予定であるため、統一的な方法として上記のメタデータの領域を同様に用いることとした。