### PR TITLE
let式内のヒープオブジェクトの寿命をletスコープ内にとどめる

### DIFF
--- a/runtime/ajisai_runtime.c
+++ b/runtime/ajisai_runtime.c
@@ -308,11 +308,11 @@ static void ajisai_mem_manager_release_from_space(AjisaiMemManager *manager) {
   int released_cell_count = 0;
 #endif // AJISAI_MEMORY_MANAGER_DEBUG_OUTPUT
 
-  while (manager->top != manager->free.bottom && manager->top->prev != manager->free.bottom) {
-    AjisaiMemCell *released = manager->top->prev;
+  while (manager->top != manager->free.bottom) {
+    AjisaiMemCell *released = manager->top;
+    manager->top = manager->top->prev;
 
-    manager->top->prev = released->prev;
-    released->prev->next = manager->top;
+    AJISAI_MEMCELL_POP_OWN(manager, released);
 
     AjisaiObject *obj = (AjisaiObject *)released->data->data;
     ajisai_object_heap_free(obj);
@@ -364,6 +364,7 @@ static void ajisai_proc_frame_scan_roots(ProcFrame *proc_frame) {
 
 #ifdef AJISAI_MEMORY_MANAGER_DEBUG_OUTPUT
   printf("[MEMORY MANAGER DEBUG] scan_roots end (%d cells going to to-space)\n", scanned_cell_count);
+  ajisai_mem_manager_display_stat(manager);
 #endif // AJISAI_MEMORY_MANAGER_DEBUG_OUTPUT
 }
 

--- a/runtime/ajisai_runtime.h
+++ b/runtime/ajisai_runtime.h
@@ -73,10 +73,10 @@ typedef enum {
 } AjisaiObjTag;
 
 enum {
-  AJISAI_HEAP_OBJ  = 0x80000000,
-  AJISAI_BLACK_OBJ = 0x40000000,
-  AJISAI_GRAY_OBJ  = 0x20000000,
-  AJISAI_OBJ_MASK  = 0x0000ffff,
+  AJISAI_HEAP_OBJ      = 0x80000000,
+  AJISAI_BLACK_OBJ     = 0x40000000,
+  AJISAI_GRAY_OBJ      = 0x20000000,
+  AJISAI_OBJ_TAG_MASK  = 0x0000ffff,
 };
 
 typedef struct AjisaiObject AjisaiObject;
@@ -86,12 +86,12 @@ typedef struct {
 } AjisaiTypeInfo;
 
 struct AjisaiObject {
-  // 上位16bitをAjisaiObjTagの値として使う。下位16bitはメタデータのための領域とする
-  AjisaiObjTag tag;
+  // 下位16bitをAjisaiObjTagの値として使う。上位16bitはメタデータのための領域とする
+  uint32_t tag;
   AjisaiTypeInfo *type_info;
 };
 
-#define AJISAI_OBJ_TAG(obj) ((obj)->tag & AJISAI_OBJ_MASK)
+#define AJISAI_OBJ_TAG(obj) ((obj)->tag & AJISAI_OBJ_TAG_MASK)
 #define AJISAI_IS_HEAP_OBJ(obj) ((obj)->tag & AJISAI_HEAP_OBJ)
 #define AJISAI_IS_GRAY_OBJ(obj) ((obj)->tag & AJISAI_GRAY_OBJ)
 #define AJISAI_IS_ALIVE_OBJ(obj, manager) ((manager)->live_color == AJISAI_BLACK ? ((obj)->tag & AJISAI_BLACK_OBJ) : !((obj)->tag & AJISAI_BLACK_OBJ))

--- a/src/acir.ts
+++ b/src/acir.ts
@@ -17,7 +17,7 @@ export type ACProcDefInst = {
 
 export type ACProcBodyInst =
   ACRootTableInitInst | ACRootTableRegInst | ACRootTableUnregInst |
-  ACProcFrameInitInst | ACProcFrameDefTmp | ACProcFrameDefTmpNoVal | ACProcFrameStoreTmp |
+  ACProcFrameInitInst | ACProcFrameDefTmpInst | ACProcFrameDefTmpNoValInst | ACProcFrameStoreTmpInst |
   ACProcReturnInst |
   ACEnvDefVarInst |
   ACIfElseInst |
@@ -34,10 +34,10 @@ export type ACRootTableRegInst = { inst: "root_table.reg", envId: number, rootTa
 export type ACRootTableUnregInst = { inst: "root_table.unreg", idx: number };
 
 export type ACProcFrameInitInst = { inst: "proc_frame.init", rootTableSize: number };
-export type ACProcFrameDefTmp = { inst: "proc_frame.deftmp", envId: number, idx: number, ty: Type, value: ACPushValInst };
-export type ACProcFrameDefTmpNoVal = { inst: "proc_frame.deftmp_noval", envId: number, idx: number, ty: Type };
-export type ACProcFrameLoadTmp = { inst: "proc_frame.load_tmp", envId: number, idx: number };
-export type ACProcFrameStoreTmp = { inst: "proc_frame.store_tmp", envId: number, idx: number, value: ACPushValInst };
+export type ACProcFrameDefTmpInst = { inst: "proc_frame.deftmp", envId: number, idx: number, ty: Type, value: ACPushValInst };
+export type ACProcFrameDefTmpNoValInst = { inst: "proc_frame.deftmp_noval", envId: number, idx: number, ty: Type };
+export type ACProcFrameLoadTmpInst = { inst: "proc_frame.load_tmp", envId: number, idx: number };
+export type ACProcFrameStoreTmpInst = { inst: "proc_frame.store_tmp", envId: number, idx: number, value: ACPushValInst };
 
 export type ACProcReturnInst = { inst: "proc.return", value: ACPushValInst };
 
@@ -47,7 +47,7 @@ export type ACPushValInst =
   ACBuiltinLoadInst |
   ACModDefsLoadInst |
   ACEnvLoadInst |
-  ACProcFrameLoadTmp |
+  ACProcFrameLoadTmpInst |
   ACBuiltinCallInst | ACBuiltinCallWithFrameInst | ACProcCallInst |
 
   ACI32ConstInst | ACI32NegInst | ACI32AddInst | ACI32SubInst | ACI32MulInst | ACI32DivInst | ACI32ModInst |

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -19,7 +19,7 @@ export type AstExprSeqNode = { nodeType: "exprSeq", exprs: AstExprNode[], ty?: T
 export type AstProcNode = { nodeType: "proc", args: AstProcArgNode[], body: AstExprSeqNode, envId: number, bodyTy?: Type, rootTableSize?: number };
 export type AstProcArgNode = { nodeType: "procArg", name: string, ty?: Type };
 
-export type AstLetNode = { nodeType: "let", declares: AstDeclareNode[], body: AstExprSeqNode, bodyTy?: Type, envId: number };
+export type AstLetNode = { nodeType: "let", declares: AstDeclareNode[], body: AstExprSeqNode, bodyTy?: Type, envId: number, rootIdx?: number, rootIndices?: number[] };
 
 export type AstDeclareNode = { nodeType: "declare", name: string, ty?: Type, value: AstExprNode };
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -9,7 +9,7 @@ export class VarEnv {
   parent_?: VarEnv;
   envKind: EnvKind;
   #variables: Map<string, Type> = new Map();
-  // #rootIndices: number[] = [];
+  #rootIndices: number[] = [];
   #freshRootId = 0;
 
   constructor(envKind: EnvKind, parent?: VarEnv) {
@@ -31,13 +31,13 @@ export class VarEnv {
 
   freshRootId(): number {
     const freshId = this.incrementTmpId();
-    // this.#rootIndices.push(freshId);
+    this.#rootIndices.push(freshId);
     return freshId;
   }
 
-  // get rootIndices(): number[] {
-  //   return this.#rootIndices.sort((a, b) => b - a);
-  // }
+  get rootIndices(): number[] {
+    return this.#rootIndices.sort((a, b) => b - a);
+  }
 
   get rootTableSize(): number {
     return this.#freshRootId;

--- a/src/semant.ts
+++ b/src/semant.ts
@@ -180,6 +180,9 @@ export class SemanticAnalyzer {
       astTy = ty;
     } else if (ast.nodeType === "let") {
       const [node, ty] = this.analyzeLet(ast, new VarEnv("let", varEnv));
+      if (mayBeHeapObj(ty)) {
+        node.rootIdx = varEnv.freshRootId();
+      }
       ast = node;
       astTy = ty;
     } else if (ast.nodeType === "if") {
@@ -319,7 +322,7 @@ export class SemanticAnalyzer {
 
     const [bodyAst, bodyTy] = this.analyzeExprSeq(ast.body, varEnv);
 
-    return [{ nodeType: "let", declares: newDeclares, body: bodyAst, bodyTy, envId: varEnv.envId }, bodyTy];
+    return [{ nodeType: "let", declares: newDeclares, body: bodyAst, bodyTy, envId: varEnv.envId, rootIndices: varEnv.rootIndices }, bodyTy];
   }
 
   private analyzeDeclare(ast: AstDeclareNode, varEnv: VarEnv): AstDeclareNode {


### PR DESCRIPTION
#1 ではヒープオブジェクトの寿命は関数単位にしていたが、let式の実装を改善して、let式内のヒープオブジェクトの寿命はletスコープ内にとどめるようにした