### PR TITLE
proc リテラルを追加

### DIFF
--- a/examples/local_proc.ajs
+++ b/examples/local_proc.ajs
@@ -1,0 +1,6 @@
+proc main() {
+    let concat = |a: str, b: str| -> str { str_concat(a, b) }
+    {
+        println_str(concat("Hello, ", "world!"))
+    }
+}

--- a/runtime/ajisai_runtime.h
+++ b/runtime/ajisai_runtime.h
@@ -70,6 +70,7 @@ void ajisai_mem_manager_append_to_to_space(AjisaiMemManager *manager, AjisaiMemC
 typedef enum {
   AJISAI_OBJ_STR,
   AJISAI_OBJ_STR_SLICE,
+  AJISAI_OBJ_PROC,
 } AjisaiObjTag;
 
 enum {
@@ -105,6 +106,14 @@ struct AjisaiString {
   AjisaiString *src;
 };
 
+typedef struct AjisaiClosure AjisaiClosure;
+struct AjisaiClosure {
+  AjisaiObject obj_header;
+  void *func_ptr;
+  void *captured_vars;
+  void (*scan_func)(AjisaiMemManager *, AjisaiObject *);
+};
+
 typedef struct ProcFrame ProcFrame;
 struct ProcFrame {
   ProcFrame *parent;
@@ -131,3 +140,6 @@ AjisaiString *ajisai_str_slice(ProcFrame *proc_frame, AjisaiString *src, int32_t
 bool ajisai_str_equal(AjisaiString *left, AjisaiString *right);
 // TODO: 反復回数指定のための数値型は符号なし整数にする
 AjisaiString *ajisai_str_repeat(ProcFrame *proc_frame, AjisaiString *src, int32_t count);
+
+AjisaiTypeInfo *ajisai_proc_type_info(void);
+AjisaiClosure *ajisai_closure_new(ProcFrame *proc_frame, void *func_ptr, void (*scan_func)(AjisaiMemManager *, AjisaiObject *));

--- a/src/acir.ts
+++ b/src/acir.ts
@@ -2,15 +2,26 @@ import { Type } from "./type.ts";
 
 export type ACModuleInst = {
   inst: "module",
-  procDecls: ACProcDeclInst[],
-  procDefs: ACProcDefInst[],
+  procDecls: ACDeclInst[],
+  procDefs: ACDefInst[],
   entry?: ACEntryInst
 };
 
+export type ACDeclInst = ACProcDeclInst | ACClosureDeclInst;
+export type ACDefInst = ACProcDefInst | ACClosureDefInst;
+
 export type ACEntryInst = { inst: "entry", body: ACProcBodyInst[] };
+
 export type ACProcDeclInst = { inst: "proc.decl", procName: string, args: [string, Type][], resultType: Type };
 export type ACProcDefInst = {
   inst: "proc.def", procName: string, args: [string, Type][], resultType: Type,
+  envId: number,
+  body: ACProcBodyInst[]
+};
+
+export type ACClosureDeclInst = { inst: "closure.decl", procName: string, args: [string, Type][], resultType: Type };
+export type ACClosureDefInst = {
+  inst: "closure.def", procName: string, args: [string, Type][], resultType: Type,
   envId: number,
   body: ACProcBodyInst[]
 };
@@ -28,6 +39,7 @@ export type ACEnvDefVarInst = { inst: "env.defvar", envId: number, varName: stri
 export type ACEnvLoadInst = { inst: "env.load", envId: number, varName: string };
 export type ACModDefsLoadInst = { inst: "mod_defs.load", varName: string };
 export type ACBuiltinLoadInst = { inst: "builtin.load", varName: string };
+export type ACClosureLoadInst = { inst: "closure.load", id: string }
 
 export type ACRootTableInitInst = { inst: "root_table.init", size: number };
 export type ACRootTableRegInst = { inst: "root_table.reg", envId: number, rootTableIdx: number, tmpVarIdx: number };
@@ -46,20 +58,24 @@ export type ACIfElseInst = { inst: "ifelse", cond: ACPushValInst, then: ACProcBo
 export type ACPushValInst =
   ACBuiltinLoadInst |
   ACModDefsLoadInst |
+  ACClosureLoadInst |
   ACEnvLoadInst |
   ACProcFrameLoadTmpInst |
-  ACBuiltinCallInst | ACBuiltinCallWithFrameInst | ACProcCallInst |
+  ACBuiltinCallInst | ACBuiltinCallWithFrameInst | ACProcCallInst | ACClosureCallInst |
 
   ACI32ConstInst | ACI32NegInst | ACI32AddInst | ACI32SubInst | ACI32MulInst | ACI32DivInst | ACI32ModInst |
   ACI32EqInst | ACI32NeInst | ACI32LtInst | ACI32LeInst | ACI32GtInst | ACI32GeInst |
 
   ACBoolConstInst | ACBoolNotInst | ACBoolEqInst | ACBoolNeInst | ACBoolAndInst | ACBoolOrInst |
 
-  ACStrConstInst;
+  ACStrConstInst |
+
+  ACClosureMakeInst;
 
 export type ACBuiltinCallInst = { inst: "builtin.call", callee: ACPushValInst, args: ACPushValInst[] };
 export type ACBuiltinCallWithFrameInst = { inst: "builtin.call_with_frame", callee: ACPushValInst, args: ACPushValInst[] };
 export type ACProcCallInst = { inst: "proc.call", callee: ACPushValInst, args: ACPushValInst[] };
+export type ACClosureCallInst = { inst: "closure.call", callee: ACPushValInst, args: ACPushValInst[], argTypes: Type[], bodyType: Type };
 
 export type ACI32ConstInst = { inst: "i32.const", value: number };
 export type ACI32NegInst = { inst: "i32.neg", operand: ACPushValInst };
@@ -84,3 +100,5 @@ export type ACBoolOrInst = { inst: "bool.or", left: ACPushValInst, right: ACPush
 
 export type ACStrMakeStaticInst = { inst: "str.make_static", id: number, value: string, len: number };
 export type ACStrConstInst = { inst: "str.const", id: number };
+
+export type ACClosureMakeInst = { inst: "closure.make", id: number };

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -16,7 +16,7 @@ export type AstExprNode = AstExprSeqNode |
 
 export type AstExprSeqNode = { nodeType: "exprSeq", exprs: AstExprNode[], ty?: Type };
 
-export type AstProcNode = { nodeType: "proc", args: AstProcArgNode[], body: AstExprSeqNode, envId: number, bodyTy?: Type, rootTableSize?: number };
+export type AstProcNode = { nodeType: "proc", args: AstProcArgNode[], body: AstExprSeqNode, envId: number, bodyTy?: Type, rootTableSize?: number, closureId?: number, ty?: Type, rootIdx?: number };
 export type AstProcArgNode = { nodeType: "procArg", name: string, ty?: Type };
 
 export type AstLetNode = { nodeType: "let", declares: AstDeclareNode[], body: AstExprSeqNode, bodyTy?: Type, envId: number, rootIdx?: number, rootIndices?: number[] };
@@ -31,7 +31,7 @@ export type AstBinaryNode = { nodeType: "binary", operator: BinOpKind, left: Ast
 export type UnOpKind = "-" | "!";
 export type AstUnaryNode = { nodeType: "unary", operator: UnOpKind, operand: AstExprNode, ty?: Type };
 
-export type AstCallNode = { nodeType: "call", callee: AstExprNode, args: AstExprNode[], ty?: Type, rootIdx?: number };
+export type AstCallNode = { nodeType: "call", callee: AstExprNode, args: AstExprNode[], ty?: Type, calleeTy?: Type, rootIdx?: number };
 
 export type AstUnitNode = { nodeType: "unit" };
 export type AstIntegerNode = { nodeType: "integer", value: number };

--- a/src/type.ts
+++ b/src/type.ts
@@ -8,7 +8,7 @@ export const isPrimitiveTypeName = (s: string): PrimitiveTypeName | null => {
   return (primitiveTypeNames as Readonly<string[]>).includes(s) ? s as PrimitiveTypeName : null;
 };
 
-export type ProcKind = "userdef" | "builtin" | "builtinWithFrame";
+export type ProcKind = "userdef" | "closure" | "builtin" | "builtinWithFrame";
 export type ProcType = { tyKind: "proc", procKind: ProcKind, argTypes: Type[], bodyType: Type };
 
 export type DummyType = { tyKind: "dummy" };
@@ -39,7 +39,7 @@ export const toCType = (ty: Type): string => {
       case "()": return "void";
     }
   } else if (ty.tyKind === "proc") {
-    throw new Error("unimplemented for proc");
+    return "AjisaiClosure *";
   }
   throw new Error("invalid type");
 };

--- a/tests/parser_test.ts
+++ b/tests/parser_test.ts
@@ -377,3 +377,56 @@ Deno.test("parsing proc definition (with expression sequence) test", () => {
     }
   );
 });
+
+Deno.test("parsing proc expression test", () => {
+  const lexer = new Lexer("let add = |a: i32, b: i32| -> i32 { a + b } { add(1, 2) }");
+  const parser = new Parser(lexer);
+  const ast = parser.parseExpr();
+
+  assertEquals(
+    ast,
+    {
+      nodeType: "let",
+      declares: [
+        {
+          nodeType: "declare",
+          name: "add",
+          value: {
+            nodeType: "proc",
+            args: [
+              { nodeType: "procArg", name: "a", ty: { tyKind: "primitive", name: "i32" } },
+              { nodeType: "procArg", name: "b", ty: { tyKind: "primitive", name: "i32" } }
+            ],
+            body: {
+              nodeType: "exprSeq",
+              exprs: [
+                {
+                  nodeType: "binary",
+                  operator: "+",
+                  left: { nodeType: "variable", name: "a", level: -1, fromEnv: -1, toEnv: -1 },
+                  right: { nodeType: "variable", name: "b", level: -1, fromEnv: -1, toEnv: -1 }
+                }
+              ]
+            },
+            envId: -1,
+            bodyTy: { tyKind: "primitive", name: "i32" }
+          }
+        },
+      ],
+      body: {
+        nodeType: "exprSeq",
+        exprs: [
+          {
+            nodeType: "call",
+            callee: { nodeType: "variable", name: "add", level: -1, fromEnv: -1, toEnv: -1 },
+            args: [
+              { nodeType: "integer", value: 1 },
+              { nodeType: "integer", value: 2 }
+            ]
+          }
+        ]
+      },
+      envId: -1
+    }
+  );
+});


### PR DESCRIPTION
let 式内で proc リテラルによって無名関数を定義し、それを呼び出し可能にした。

ただし、以下の機能はまだない。今後実装する：
- [ ] proc リテラルから外のスコープの変数を捕捉する
- [ ] 高階関数の機能（クロージャオブジェクトを引数に取ったり、戻り値でクロージャオブジェクトを返したりする）
  - モジュールレベルの関数を他の関数の引数に渡すときは、クロージャオブジェクトで包む必要がある