### PR TITLE
引数ゼロのprocリテラルがうまくパースできない問題を修正

### DIFF
--- a/examples/nested_proc_literal.ajs
+++ b/examples/nested_proc_literal.ajs
@@ -1,0 +1,20 @@
+proc main() {
+    let t0 = || {
+        println_str("t0 start");
+        let t1 = || {
+            println_str("t1 start");
+            let t2 = || {
+                println_str("t2 start");
+                println_str("t2 end")
+            } {
+                t2()
+            };
+            println_str("t1 end")
+        } {
+            t1()
+        };
+        println_str("t0 end")
+    } {
+        t0()
+    }
+}

--- a/src/c_src_printer.ts
+++ b/src/c_src_printer.ts
@@ -122,10 +122,10 @@ const printProcBodyInst = async (writer: WritableStreamDefaultWriter, encoder: T
     case "builtin.call":
     case "builtin.call_with_frame":
     case "proc.call":
+    case "closure.call":
       line = `  ${makePushValLiteral(inst)};\n`;
       break;
     case "str.make_static":
-      // TODO: collect_root_func を設定
       line = `  static AjisaiString static_str${inst.id} = { .obj_header = { .tag = AJISAI_OBJ_STR }, .len = ${inst.len}, .value = ${inst.value} };\n  static_str${inst.id}.obj_header.type_info = ajisai_str_type_info();\n`;
       break;
     default:

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -83,7 +83,10 @@ export class Parser {
 
   parseExpr(): AstExprNode {
     if (this.eat("|")) {
-      return this.parseProc();
+      return this.parseProc(false);
+    }
+    if (this.eat("||")) {
+      return this.parseProc(true);
     }
     if (this.eat("let")) {
       return this.parseLet();
@@ -144,15 +147,17 @@ export class Parser {
     throw new Error("Could not parse declaration");
   }
 
-  private parseProc(): AstProcNode {
+  private parseProc(noArgs: boolean): AstProcNode {
     const args = [];
 
-    if (!this.eat("|")) {
-      while (true) {
-        args.push(this.parseProcArg());
-        if (!this.eat(",")) break;
+    if (!noArgs) {
+      if (!this.eat("|")) {
+        while (true) {
+          args.push(this.parseProcArg());
+          if (!this.eat(",")) break;
+        }
+        this.expect("|");
       }
-      this.expect("|");
     }
 
     let bodyTy: Type;

--- a/tests/parser_test.ts
+++ b/tests/parser_test.ts
@@ -430,3 +430,49 @@ Deno.test("parsing proc expression test", () => {
     }
   );
 });
+
+Deno.test("parsing proc expression (without arguments) test", () => {
+  const lexer = new Lexer("let hello = || { println_str(\"Hello, world!\") } { hello() }");
+  const parser = new Parser(lexer);
+  const ast = parser.parseExpr();
+
+  assertEquals(
+    ast,
+    {
+      nodeType: "let",
+      declares: [
+        {
+          nodeType: "declare",
+          name: "hello",
+          value: {
+            nodeType: "proc",
+            args: [],
+            body: {
+              nodeType: "exprSeq",
+              exprs: [
+                {
+                  nodeType: "call",
+                  callee: { nodeType: "variable", name: "println_str", level: -1, fromEnv: -1, toEnv: -1 },
+                  args: [{ nodeType: "string", value: '"Hello, world!"', len: 0 }]
+                }
+              ]
+            },
+            envId: -1,
+            bodyTy: { tyKind: "primitive", name: "()" }
+          }
+        },
+      ],
+      body: {
+        nodeType: "exprSeq",
+        exprs: [
+          {
+            nodeType: "call",
+            callee: { nodeType: "variable", name: "hello", level: -1, fromEnv: -1, toEnv: -1 },
+            args: []
+          }
+        ]
+      },
+      envId: -1
+    }
+  );
+});


### PR DESCRIPTION
procリテラルにおいて、引数ゼロだと `||` が一つの演算子として字句解析され、構文解析でそのパターンを考慮していなかったためにうまくパースできなかった。この問題を修正。

また、戻り値を変数束縛せずに捨てるようなクロージャの呼び出しでCコードを出力しないバグがあったので、これもついでに修正した。