### PR TITLE
proc を第一級オブジェクトとして扱えるようにする

### DIFF
--- a/examples/higher_order_function.ajs
+++ b/examples/higher_order_function.ajs
@@ -1,0 +1,20 @@
+proc print_proc_result(a: i32, b: i32, p: proc(i32, i32) -> i32) {
+    println_i32(p(a, b))
+}
+
+proc get_sub_proc() -> proc(i32, i32) -> i32 {
+    |a: i32, b: i32| -> i32 { a - b }
+}
+
+proc main() {
+    let
+        a   = 2,
+        b   = 3,
+        add = |a: i32, b: i32| -> i32 { a + b },
+        mul = |a: i32, b: i32| -> i32 { a * b }
+    {
+        print_proc_result(a, b, add);
+        print_proc_result(a, b, mul);
+        println_i32(get_sub_proc()(a, b))
+    }
+}

--- a/examples/higher_order_function.ajs
+++ b/examples/higher_order_function.ajs
@@ -6,15 +6,20 @@ proc get_sub_proc() -> proc(i32, i32) -> i32 {
     |a: i32, b: i32| -> i32 { a - b }
 }
 
+proc div_proc(a: i32, b: i32) -> i32 {
+    a / b
+}
+
 proc main() {
     let
-        a   = 2,
-        b   = 3,
+        a   = 10,
+        b   = 5,
         add = |a: i32, b: i32| -> i32 { a + b },
         mul = |a: i32, b: i32| -> i32 { a * b }
     {
         print_proc_result(a, b, add);
+        print_proc_result(a, b, get_sub_proc());
         print_proc_result(a, b, mul);
-        println_i32(get_sub_proc()(a, b))
+        print_proc_result(a, b, div_proc)
     }
 }

--- a/examples/module_level_proc_as_object.ajs
+++ b/examples/module_level_proc_as_object.ajs
@@ -1,0 +1,15 @@
+proc test_userdef(n: i32) {
+    println_i32(n * 2)
+}
+
+proc main() {
+    let
+        one = println_i32,
+        two = test_userdef,
+        three = |n: i32| { println_i32(n * 3) }
+    {
+        one(10);
+        two(10);
+        three(10)
+    }
+}

--- a/runtime/ajisai_runtime.c
+++ b/runtime/ajisai_runtime.c
@@ -438,34 +438,34 @@ void ajisai_gc_start(ProcFrame *proc_frame) {
   mem_manager->gc_in_progress = false;
 }
 
-void ajisai_print_i32(int32_t value) {
+void ajisai_print_i32(ProcFrame *proc_frame, int32_t value) {
   printf("%d", value);
 }
 
-void ajisai_println_i32(int32_t value) {
-  ajisai_print_i32(value);
+void ajisai_println_i32(ProcFrame *proc_frame, int32_t value) {
+  ajisai_print_i32(proc_frame, value);
   putchar('\n');
 }
 
-void ajisai_print_bool(bool value) {
+void ajisai_print_bool(ProcFrame *proc_frame, bool value) {
   printf("%s", value ? "true" : "false");
 }
 
-void ajisai_println_bool(bool value) {
-  ajisai_print_bool(value);
+void ajisai_println_bool(ProcFrame *proc_frame, bool value) {
+  ajisai_print_bool(proc_frame, value);
   putchar('\n');
 }
 
-void ajisai_print_str(AjisaiString *value) {
+void ajisai_print_str(ProcFrame *proc_frame, AjisaiString *value) {
   printf("%.*s", (int)value->len, value->value);
 }
 
-void ajisai_println_str(AjisaiString *value) {
-  ajisai_print_str(value);
+void ajisai_println_str(ProcFrame *proc_frame, AjisaiString *value) {
+  ajisai_print_str(proc_frame, value);
   putchar('\n');
 }
 
-void ajisai_flush(void) {
+void ajisai_flush(ProcFrame *proc_frame) {
   fflush(stdout);
 }
 
@@ -561,7 +561,7 @@ AjisaiString *ajisai_str_slice(ProcFrame *proc_frame, AjisaiString *src, int32_t
   return ajisai_str_new(proc_frame, AJISAI_OBJ_STR_SLICE, end - start, src->value + start, src);
 }
 
-bool ajisai_str_equal(AjisaiString *left, AjisaiString *right) {
+bool ajisai_str_equal(ProcFrame *proc_frame, AjisaiString *left, AjisaiString *right) {
   if (left->len != right->len)
     return false;
   return memcmp(left->value, right->value, left->len) == 0;

--- a/runtime/ajisai_runtime.h
+++ b/runtime/ajisai_runtime.h
@@ -125,19 +125,19 @@ struct ProcFrame {
 AjisaiObject *ajisai_object_alloc(ProcFrame *proc_frame, size_t size);
 void ajisai_gc_start(ProcFrame *proc_frame);
 
-void ajisai_print_i32(int32_t value);
-void ajisai_println_i32(int32_t value);
-void ajisai_print_bool(bool value);
-void ajisai_println_bool(bool value);
-void ajisai_print_str(AjisaiString *value);
-void ajisai_println_str(AjisaiString *value);
-void ajisai_flush(void);
+void ajisai_print_i32(ProcFrame *proc_frame, int32_t value);
+void ajisai_println_i32(ProcFrame *proc_frame, int32_t value);
+void ajisai_print_bool(ProcFrame *proc_frame, bool value);
+void ajisai_println_bool(ProcFrame *proc_frame, bool value);
+void ajisai_print_str(ProcFrame *proc_frame, AjisaiString *value);
+void ajisai_println_str(ProcFrame *proc_frame, AjisaiString *value);
+void ajisai_flush(ProcFrame *proc_frame);
 
 AjisaiTypeInfo *ajisai_str_type_info(void);
 AjisaiString *ajisai_str_concat(ProcFrame *proc_frame, AjisaiString *a, AjisaiString *b);
 // TODO: 範囲指定のための数値型は符号なし整数にする
 AjisaiString *ajisai_str_slice(ProcFrame *proc_frame, AjisaiString *src, int32_t start, int32_t end);
-bool ajisai_str_equal(AjisaiString *left, AjisaiString *right);
+bool ajisai_str_equal(ProcFrame *proc_frame, AjisaiString *left, AjisaiString *right);
 // TODO: 反復回数指定のための数値型は符号なし整数にする
 AjisaiString *ajisai_str_repeat(ProcFrame *proc_frame, AjisaiString *src, int32_t count);
 

--- a/src/acir.ts
+++ b/src/acir.ts
@@ -1,4 +1,4 @@
-import { Type } from "./type.ts";
+import { ProcKind, Type } from "./type.ts";
 
 export type ACModuleInst = {
   inst: "module",
@@ -32,14 +32,14 @@ export type ACProcBodyInst =
   ACProcReturnInst |
   ACEnvDefVarInst |
   ACIfElseInst |
-  ACStrMakeStaticInst |
+  ACStrMakeStaticInst | ACClosureMakeStaticInst |
   ACPushValInst;
 
 export type ACEnvDefVarInst = { inst: "env.defvar", envId: number, varName: string, ty: Type, value: ACPushValInst };
 export type ACEnvLoadInst = { inst: "env.load", envId: number, varName: string };
 export type ACModDefsLoadInst = { inst: "mod_defs.load", varName: string };
 export type ACBuiltinLoadInst = { inst: "builtin.load", varName: string };
-export type ACClosureLoadInst = { inst: "closure.load", id: string }
+export type ACClosureLoadInst = { inst: "closure.load", id: string };
 
 export type ACRootTableInitInst = { inst: "root_table.init", size: number };
 export type ACRootTableRegInst = { inst: "root_table.reg", envId: number, rootTableIdx: number, tmpVarIdx: number };
@@ -61,7 +61,7 @@ export type ACPushValInst =
   ACClosureLoadInst |
   ACEnvLoadInst |
   ACProcFrameLoadTmpInst |
-  ACBuiltinCallInst | ACBuiltinCallWithFrameInst | ACProcCallInst | ACClosureCallInst |
+  ACProcCallInst | ACClosureCallInst |
 
   ACI32ConstInst | ACI32NegInst | ACI32AddInst | ACI32SubInst | ACI32MulInst | ACI32DivInst | ACI32ModInst |
   ACI32EqInst | ACI32NeInst | ACI32LtInst | ACI32LeInst | ACI32GtInst | ACI32GeInst |
@@ -70,10 +70,8 @@ export type ACPushValInst =
 
   ACStrConstInst |
 
-  ACClosureMakeInst;
+  ACClosureConstInst | ACClosureMakeInst;
 
-export type ACBuiltinCallInst = { inst: "builtin.call", callee: ACPushValInst, args: ACPushValInst[] };
-export type ACBuiltinCallWithFrameInst = { inst: "builtin.call_with_frame", callee: ACPushValInst, args: ACPushValInst[] };
 export type ACProcCallInst = { inst: "proc.call", callee: ACPushValInst, args: ACPushValInst[] };
 export type ACClosureCallInst = { inst: "closure.call", callee: ACPushValInst, args: ACPushValInst[], argTypes: Type[], bodyType: Type };
 
@@ -101,4 +99,6 @@ export type ACBoolOrInst = { inst: "bool.or", left: ACPushValInst, right: ACPush
 export type ACStrMakeStaticInst = { inst: "str.make_static", id: number, value: string, len: number };
 export type ACStrConstInst = { inst: "str.const", id: number };
 
+export type ACClosureMakeStaticInst = { inst: "closure.make_static", id: number, procKind: ProcKind, name: string };
+export type ACClosureConstInst = { inst: "closure.const", id: number };
 export type ACClosureMakeInst = { inst: "closure.make", id: number };

--- a/src/semant.ts
+++ b/src/semant.ts
@@ -80,7 +80,7 @@ const makeDefTypeMap = (module: AstModuleNode): DefTypeMap => {
     "str_concat",
     {
       tyKind: "proc",
-      procKind: "builtinWithFrame",
+      procKind: "builtin",
       argTypes: [{ tyKind: "primitive", name: "str" }, { tyKind: "primitive", name: "str" }],
       bodyType: { tyKind: "primitive", name: "str" }
     }
@@ -89,7 +89,7 @@ const makeDefTypeMap = (module: AstModuleNode): DefTypeMap => {
     "str_slice",
     {
       tyKind: "proc",
-      procKind: "builtinWithFrame",
+      procKind: "builtin",
       // TODO: 範囲指定のための数値型は符号なし整数にする
       argTypes: [{ tyKind: "primitive", name: "str" }, { tyKind: "primitive", name: "i32" }, { tyKind: "primitive", name: "i32" }],
       bodyType: { tyKind: "primitive", name: "str" }
@@ -108,7 +108,7 @@ const makeDefTypeMap = (module: AstModuleNode): DefTypeMap => {
     "str_repeat",
     {
       tyKind: "proc",
-      procKind: "builtinWithFrame",
+      procKind: "builtin",
       // TODO: 反復回数指定のための数値型は符号なし整数にする
       argTypes: [{ tyKind: "primitive", name: "str" }, { tyKind: "primitive", name: "i32" }],
       bodyType: { tyKind: "primitive", name: "str" }
@@ -118,7 +118,7 @@ const makeDefTypeMap = (module: AstModuleNode): DefTypeMap => {
     "gc_start",
     {
       tyKind: "proc",
-      procKind: "builtinWithFrame",
+      procKind: "builtin",
       argTypes: [],
       bodyType: { tyKind: "primitive", name: "()" }
     }
@@ -369,10 +369,14 @@ export class SemanticAnalyzer {
 
   private analyzeDeclare(ast: AstDeclareNode, varEnv: VarEnv): AstDeclareNode {
     const { name, ty, value } = ast;
-    const [ exprAst, exprTy ] = this.analyzeExpr(value, varEnv);
+    const [ exprAst, exprTy_ ] = this.analyzeExpr(value, varEnv);
 
     // TODO: integerリテラルをi32と対応させているが、今後u32等の他の型も登場させると対応関係が崩れる
     //       リテラルと型の対応が一対一でなくなった時に実装を変える必要がある
+    let exprTy = exprTy_;
+    if (exprTy.tyKind === "proc" && exprTy.procKind !== "closure") {
+      exprTy = { ...exprTy_, ...{ procKind: "closure" } };
+    }
     if (ty) {
       if (!tyEqual(ty, exprTy)) {
         throw new Error("mismatch type in declaration");

--- a/src/semant.ts
+++ b/src/semant.ts
@@ -332,25 +332,27 @@ export class SemanticAnalyzer {
       }
       return [{ nodeType: "call", callee: procAst, args, ty: procTy.bodyType, calleeTy: procTy }, procTy.bodyType];
     }
-    if (ast.callee.nodeType === "variable") {
-      const [varAst, varTy] = this.analyzeExpr(ast.callee, varEnv);
-      if (varTy.tyKind !== "proc") {
-        throw new Error("invalid callee type");
-      }
-      if (ast.args.length !== varTy.argTypes.length) {
-        throw new Error(`invalid number of args: expected ${varTy.argTypes.length}, but got ${ast.args.length}`);
-      }
-      const args = [];
-      for (let i = 0; i < varTy.argTypes.length; i++) {
-        const [argAst, argTy] = this.analyzeExpr(ast.args[i], varEnv);
-        if (!tyEqual(varTy.argTypes[i], argTy)) {
-          throw new Error("invalid arg type");
-        }
-        args.push(argAst);
-      }
-      return [{ nodeType: "call", callee: varAst, args, ty: varTy.bodyType, calleeTy: varTy }, varTy.bodyType];
+
+    const [varAst, varTy] = this.analyzeExpr(ast.callee, varEnv);
+
+    if (varTy.tyKind !== "proc") {
+      throw new Error("invalid callee type");
     }
-    throw new Error("invalid callee type");
+
+    if (ast.args.length !== varTy.argTypes.length) {
+      throw new Error(`invalid number of args: expected ${varTy.argTypes.length}, but got ${ast.args.length}`);
+    }
+
+    const args = [];
+    for (let i = 0; i < varTy.argTypes.length; i++) {
+      const [argAst, argTy] = this.analyzeExpr(ast.args[i], varEnv);
+      if (!tyEqual(varTy.argTypes[i], argTy)) {
+        throw new Error("invalid arg type");
+      }
+      args.push(argAst);
+    }
+
+    return [{ nodeType: "call", callee: varAst, args, ty: varTy.bodyType, calleeTy: varTy }, varTy.bodyType];
   }
 
   private analyzeLet(ast: AstLetNode, varEnv: VarEnv): [AstLetNode, Type] {

--- a/src/type.ts
+++ b/src/type.ts
@@ -8,7 +8,7 @@ export const isPrimitiveTypeName = (s: string): PrimitiveTypeName | null => {
   return (primitiveTypeNames as Readonly<string[]>).includes(s) ? s as PrimitiveTypeName : null;
 };
 
-export type ProcKind = "userdef" | "closure" | "builtin" | "builtinWithFrame";
+export type ProcKind = "userdef" | "closure" | "builtin";
 export type ProcType = { tyKind: "proc", procKind: ProcKind, argTypes: Type[], bodyType: Type };
 
 export type DummyType = { tyKind: "dummy" };


### PR DESCRIPTION
以下の作業により実現する：

- proc の型シグネチャを記述可能にする（`proc(type, ...) -> type` という形式）
- モジュールレベルの proc（ユーザー定義 or 組み込み関数）を let 式で変数に束縛できるようにする（クロージャとして外部のローカル変数を動的に捕捉しないため、静的に割り当てられたクロージャとして表現できる）