### PR TITLE
文字列スライスの実装を改善

### DIFF
--- a/runtime/ajisai_runtime.h
+++ b/runtime/ajisai_runtime.h
@@ -140,6 +140,8 @@ AjisaiString *ajisai_str_slice(ProcFrame *proc_frame, AjisaiString *src, int32_t
 bool ajisai_str_equal(ProcFrame *proc_frame, AjisaiString *left, AjisaiString *right);
 // TODO: 反復回数指定のための数値型は符号なし整数にする
 AjisaiString *ajisai_str_repeat(ProcFrame *proc_frame, AjisaiString *src, int32_t count);
+// TODO: 戻り値の型は符号なし整数にする
+int32_t ajisai_str_len(ProcFrame *proc_frame, AjisaiString *s);
 
 AjisaiTypeInfo *ajisai_proc_type_info(void);
 AjisaiClosure *ajisai_closure_new(ProcFrame *proc_frame, void *func_ptr, void (*scan_func)(AjisaiMemManager *, AjisaiObject *));

--- a/src/semant.ts
+++ b/src/semant.ts
@@ -115,6 +115,17 @@ const makeDefTypeMap = (module: AstModuleNode): DefTypeMap => {
     }
   );
   defTypeMap.set(
+    "str_len",
+    {
+      tyKind: "proc",
+      procKind: "builtin",
+      // TODO: 戻り値の型は符号なし整数にする
+      argTypes: [{ tyKind: "primitive", name: "str" }],
+      bodyType: { tyKind: "primitive", name: "i32" }
+    }
+  );
+
+  defTypeMap.set(
     "gc_start",
     {
       tyKind: "proc",


### PR DESCRIPTION
文字列スライスからさらに繰り返しスライスを取ると、最後に生成したスライスが解放されない限り、一連のスライスの列がずっとメモリリークしてしまう。これはスライスがスライスを `src` として持てるようにしているせいなので、文字列データを持っている文字列オブジェクトを直接参照するようにした

（ついでにビルトイン関数に `str_len` を追加した）