### PR TITLE
`val <identifier>: <type> = <expression>;` の構文を追加

### DIFF
--- a/examples/main_with_val.ajs
+++ b/examples/main_with_val.ajs
@@ -1,0 +1,3 @@
+val main: func() = func() {
+    println_str("hello!")
+};

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -16,7 +16,8 @@ export type AstExprNode = AstExprSeqNode |
 
 export type AstExprSeqNode = { nodeType: "exprSeq", exprs: AstExprNode[], ty?: Type };
 
-export type AstFuncNode = { nodeType: "func", args: AstFuncArgNode[], body: AstExprSeqNode, envId: number, bodyTy?: Type, rootTableSize?: number, closureId?: number, ty?: Type, rootIdx?: number };
+// NOTE: bodyTy はコードで指定なしの時にユニット型になることに注意する
+export type AstFuncNode = { nodeType: "func", args: AstFuncArgNode[], body: AstExprSeqNode, envId: number, bodyTy: Type, rootTableSize?: number, closureId?: number, ty?: Type, rootIdx?: number };
 export type AstFuncArgNode = { nodeType: "funcArg", name: string, ty?: Type };
 
 export type AstLetNode = { nodeType: "let", declares: AstDeclareNode[], body: AstExprSeqNode, bodyTy?: Type, envId: number, rootIdx?: number, rootIndices?: number[] };

--- a/src/token.ts
+++ b/src/token.ts
@@ -3,7 +3,7 @@ export type TokenType =
   | "," | ":" | ";" | "|" | "(" | ")" | "{" | "}"
   | "->"
   | "true" | "false"
-  | "else" | "if" | "let" | "func"
+  | "else" | "if" | "let" | "func" | "val"
   | "identifier" | "integer" | "string"
   | "eof";
 
@@ -13,6 +13,6 @@ export type Token = Readonly<MutableToken>;
 export const printToken = (token: Token) => console.log(`Token { tokenType: ${token.tokenType}, value: ${token.value} }`);
 
 export type Keyword = Extract<TokenType, (typeof keywords)[number]>;
-const keywords = ["true", "false", "else", "if", "let", "func"] as const;
+const keywords = ["true", "false", "else", "if", "let", "func", "val"] as const;
 
 export const isKeyword = (s: string): Keyword | null => (keywords as Readonly<string[]>).includes(s) ? s as Keyword : null;

--- a/tests/lexer_test.ts
+++ b/tests/lexer_test.ts
@@ -117,3 +117,18 @@ func main() -> () {
     assertEquals(token, { tokenType, value });
   }
 });
+
+Deno.test("lexing val statement test", () => {
+  const src = "val answer: i32 = 42;";
+  const lexer = new Lexer(src);
+
+  const typeAndValues: [TokenType, string][] = [
+    ["val", "val"], ["identifier", "answer"], [":", ":"], ["identifier", "i32"],
+    ["=", "="], ["integer", "42"], [";", ";"]
+  ];
+
+  for (const [tokenType, value] of typeAndValues) {
+    const token = lexer.nextToken();
+    assertEquals(token, { tokenType, value });
+  }
+});

--- a/tests/parser_test.ts
+++ b/tests/parser_test.ts
@@ -117,11 +117,13 @@ Deno.test("parsing let expression test", () => {
         {
           nodeType: "declare",
           name: "a",
+          ty: undefined,
           value: { nodeType: "integer", value: 1 }
         },
         {
           nodeType: "declare",
           name: "b",
+          ty: undefined,
           value: { nodeType: "integer", value: 2 }
         }
       ],
@@ -242,6 +244,7 @@ Deno.test("parsing func definition test", () => {
                   }
                 ]
               },
+              bodyTy: { tyKind: "primitive", name: "i32" },
               envId: -1
             }
           }
@@ -300,6 +303,7 @@ Deno.test("parsing empty main func test", () => {
               nodeType: "func",
               args: [],
               body: { nodeType: "exprSeq", exprs: [{ nodeType: "unit" }] },
+              bodyTy: { tyKind: "primitive", name: "()" },
               envId: -1
             }
           }
@@ -369,6 +373,7 @@ Deno.test("parsing func definition (with expression sequence) test", () => {
                   }
                 ]
               },
+              bodyTy: { tyKind: "primitive", name: "i32" },
               envId: -1
             }
           }
@@ -391,6 +396,7 @@ Deno.test("parsing func expression test", () => {
         {
           nodeType: "declare",
           name: "add",
+          ty: undefined,
           value: {
             nodeType: "func",
             args: [
@@ -444,6 +450,7 @@ Deno.test("parsing func expression (without arguments) test", () => {
         {
           nodeType: "declare",
           name: "hello",
+          ty: undefined,
           value: {
             nodeType: "func",
             args: [],
@@ -503,6 +510,77 @@ Deno.test("parsing immediately invoked function test", () => {
         bodyTy: { tyKind: "primitive", name: "()" }
       },
       args: []
+    }
+  );
+});
+
+Deno.test("parsing val definition test", () => {
+  const lexer = new Lexer("val a: i32 = 1 + 2;");
+  const parser = new Parser(lexer);
+  const ast = parser.parse();
+
+  assertEquals(
+    ast,
+    {
+      nodeType: "module",
+      defs: [
+        {
+          nodeType: "def",
+          declare: {
+            nodeType: "declare",
+            name: "a",
+            ty: {
+              tyKind: "primitive",
+              name: "i32"
+            },
+            value: {
+              nodeType: "binary",
+              operator: "+",
+                  left: { nodeType: "integer", value: 1 },
+                  right: { nodeType: "integer", value: 2 }
+
+            }
+          }
+        }
+      ]
+    }
+  );
+});
+
+Deno.test("parsing empty main func (as val definition) test", () => {
+  const lexer = new Lexer("val main: func() = func() { () };");
+  const parser = new Parser(lexer);
+  const ast = parser.parse();
+
+  assertEquals(
+    ast,
+    {
+      nodeType: "module",
+      defs: [
+        {
+          nodeType: "def",
+          declare: {
+            nodeType: "declare",
+            name: "main",
+            ty: {
+              tyKind: "func",
+              funcKind: "userdef",
+              argTypes: [],
+              bodyType: {
+                tyKind: "primitive",
+                name: "()"
+              }
+            },
+            value: {
+              nodeType: "func",
+              args: [],
+              body: { nodeType: "exprSeq", exprs: [{ nodeType: "unit" }] },
+              bodyTy: { tyKind: "primitive", name: "()" },
+              envId: -1
+            }
+          }
+        }
+      ]
     }
   );
 });


### PR DESCRIPTION
この PR では構文解析までの対応にとどまる。
`val answer: i32 = 42;` のようなコードは構文解析できるがコンパイルできない。
ただし、モジュールレベルの関数定義を `val ...` 構文で書いたものは現段階でもすでにコンパイル可能になっている。