### PR TITLE
let 式の構文を変更

### DIFF
--- a/examples/def_and_call_func.ajs
+++ b/examples/def_and_call_func.ajs
@@ -4,12 +4,12 @@ func add(a: i32, b: i32) -> i32 {
 
 func main() {
     let
-        a =
-            let a = 1, b = 2 {
+        val a =
+            let val a = 1, val b = 2 {
                 a + b
-            },
-        b =
-            let a = 3, b = 4 {
+            }
+        val b =
+            let val a = 3, val b = 4 {
                 a + b
             }
     {

--- a/examples/higher_order_function.ajs
+++ b/examples/higher_order_function.ajs
@@ -12,10 +12,10 @@ func div_func(a: i32, b: i32) -> i32 {
 
 func main() {
     let
-        a   = 10,
-        b   = 5,
-        add = func(a: i32, b: i32) -> i32 { a + b },
-        mul = func(a: i32, b: i32) -> i32 { a * b }
+        val a = 10
+        val b = 5
+        func add(a: i32, b: i32) -> i32 { a + b }
+        func mul(a: i32, b: i32) -> i32 { a * b }
     {
         print_func_result(a, b, add);
         print_func_result(a, b, get_sub_func());

--- a/examples/local_func.ajs
+++ b/examples/local_func.ajs
@@ -1,5 +1,5 @@
 func main() {
-    let concat = func(a: str, b: str) -> str { str_concat(a, b) }
+    let func concat(a: str, b: str) -> str { str_concat(a, b) }
     {
         println_str(concat("Hello, ", "world!"))
     }

--- a/examples/module_level_func_as_object.ajs
+++ b/examples/module_level_func_as_object.ajs
@@ -4,9 +4,9 @@ func test_userdef(n: i32) {
 
 func main() {
     let
-        one = println_i32,
-        two = test_userdef,
-        three = func(n: i32) { println_i32(n * 3) }
+        val one = println_i32
+        val two = test_userdef
+        val three = func(n: i32) { println_i32(n * 3) }
     {
         one(10);
         two(10);

--- a/examples/nested_func_literal.ajs
+++ b/examples/nested_func_literal.ajs
@@ -1,9 +1,9 @@
 func main() {
-    let t0 = func() {
+    let val t0 = func() {
         println_str("t0 start");
-        let t1 = func() {
+        let val t1 = func() {
             println_str("t1 start");
-            let t2 = func() {
+            let val t2 = func() {
                 println_str("t2 start");
                 println_str("t2 end")
             } {

--- a/examples/nested_let.ajs
+++ b/examples/nested_let.ajs
@@ -1,7 +1,7 @@
 func main() {
-    let a = 2,
-        b = let { 3 + a }
+    let val a = 2
+        val b = let { 3 + a }
     {
-        println_i32(let c = b * 3 { c + 10 })
+        println_i32(let val c = b * 3 { c + 10 })
     }
 }

--- a/examples/nested_let_and_if.ajs
+++ b/examples/nested_let_and_if.ajs
@@ -1,10 +1,10 @@
 func main() {
     println_i32(
-        let a = 3,
-            b = if a == 2 { 2 } else { 5 }
+        let val a = 3
+            val b = if a == 2 { 2 } else { 5 }
         {
             if a != 1 {
-                let c = b { c }
+                let val c = b { c }
             } else {
                 42
             }

--- a/examples/str_functions.ajs
+++ b/examples/str_functions.ajs
@@ -2,7 +2,7 @@ func print_equal(src: str, value: str, count: i32, end: i32) {
     if count == end {
         ()
     } else {
-        let repeated = str_repeat(src, count) {
+        let val repeated = str_repeat(src, count) {
             print_str("count: "); println_i32(count);
             print_str("\t\""); print_str(repeated); print_str("\" == \""); print_str(value); print_str("\": "); println_bool(str_equal(repeated, value))
         };

--- a/tests/lexer_test.ts
+++ b/tests/lexer_test.ts
@@ -63,13 +63,13 @@ Deno.test("skip whitespaces test", () => {
 });
 
 Deno.test("lexing let expression test", () => {
-  const src = "let a = 1, b = 2 { println_i32(a + b) }"
+  const src = "let val a = 1, val b = 2 { println_i32(a + b) }"
   const lexer = new Lexer(src);
 
   const typeAndValues: [TokenType, string][] = [
     ["let", "let"],
-    ["identifier", "a"], ["=", "="], ["integer", "1"], [",", ","],
-    ["identifier", "b"], ["=", "="], ["integer", "2"],
+    ["val", "val"], ["identifier", "a"], ["=", "="], ["integer", "1"], [",", ","],
+    ["val", "val"], ["identifier", "b"], ["=", "="], ["integer", "2"],
     ["{", "{"],
     ["identifier", "println_i32"], ["(", "("], ["identifier", "a"], ["+", "+"], ["identifier", "b"], [")", ")"],
     ["}", "}"]

--- a/tests/parser_test.ts
+++ b/tests/parser_test.ts
@@ -105,7 +105,7 @@ Deno.test("parsing grouped binary node test", () => {
 });
 
 Deno.test("parsing let expression test", () => {
-  const lexer = new Lexer("let a = 1, b = 2 { a + b }");
+  const lexer = new Lexer("let val a = 1, val b = 2 { a + b }");
   const parser = new Parser(lexer);
   const ast = parser.parseExpr();
 
@@ -384,7 +384,7 @@ Deno.test("parsing func definition (with expression sequence) test", () => {
 });
 
 Deno.test("parsing func expression test", () => {
-  const lexer = new Lexer("let add = func(a: i32, b: i32) -> i32 { a + b } { add(1, 2) }");
+  const lexer = new Lexer("let val add = func(a: i32, b: i32) -> i32 { a + b } { add(1, 2) }");
   const parser = new Parser(lexer);
   const ast = parser.parseExpr();
 
@@ -438,7 +438,7 @@ Deno.test("parsing func expression test", () => {
 });
 
 Deno.test("parsing func expression (without arguments) test", () => {
-  const lexer = new Lexer("let hello = func() { println_str(\"Hello, world!\") } { hello() }");
+  const lexer = new Lexer("let val hello = func() { println_str(\"Hello, world!\") } { hello() }");
   const parser = new Parser(lexer);
   const ast = parser.parseExpr();
 
@@ -581,6 +581,84 @@ Deno.test("parsing empty main func (as val definition) test", () => {
           }
         }
       ]
+    }
+  );
+});
+
+Deno.test("parsing let func declare test", () => {
+  const lexer = new Lexer(`
+let val hello = "hello "
+    val world = "world!"
+    func display() { println_str(str_concat(hello, world)) }
+{ display() }
+`);
+  const parser = new Parser(lexer);
+  const ast = parser.parseExpr();
+
+  assertEquals(
+    ast,
+    {
+      nodeType: "let",
+      declares: [
+        {
+          nodeType: "declare",
+          name: "hello",
+          ty: undefined,
+          value: { nodeType: "string", value: '"hello "', len: 0 }
+        },
+        {
+          nodeType: "declare",
+          name: "world",
+          ty: undefined,
+          value: { nodeType: "string", value: '"world!"', len: 0 }
+        },
+        {
+          nodeType: "declare",
+          name: "display",
+          ty: {
+            tyKind: "func",
+            funcKind: "closure",
+            argTypes: [],
+            bodyType: { tyKind: "primitive", name: "()" }
+          },
+          value: {
+            nodeType: "func",
+            args: [],
+            body: {
+              nodeType: "exprSeq",
+              exprs: [
+                {
+                  nodeType: "call",
+                  callee: { nodeType: "variable", name: "println_str", level: -1, fromEnv: -1, toEnv: -1 },
+                  args: [
+                    {
+                      nodeType: "call",
+                      callee: { nodeType: "variable", name: "str_concat", level: -1, fromEnv: -1, toEnv: -1 },
+                      args: [
+                        { nodeType: "variable", name: "hello", level: -1, fromEnv: -1, toEnv: -1 },
+                        { nodeType: "variable", name: "world", level: -1, fromEnv: -1, toEnv: -1 }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            envId: -1,
+            bodyTy: { tyKind: "primitive", name: "()" }
+          }
+        },
+      ],
+      body: {
+        nodeType: "exprSeq",
+        exprs: [
+          {
+            nodeType: "call",
+            callee: { nodeType: "variable", name: "display", level: -1, fromEnv: -1, toEnv: -1 },
+            args: []
+          }
+        ]
+      },
+      envId: -1
     }
   );
 });


### PR DESCRIPTION
`let a = 1, a = 2 { a + b }` のような構文から、`let val a = 1, val a = 2 { a + b }` のように `val` キーワードを使う形に変更。`,` は書いても書かなくても良いが、一行に複数の変数定義を書くと `,` がないと読みづらいので書けるようにしている。

また、合わせて `let func hoge() { ... } { hoge() }` のようにローカル関数を定義できるようにした。