### PR TITLE
module の初期的な実装

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -11,7 +11,7 @@ if (import.meta.main) {
 
     const lexer = new Lexer(source);
     const parser = new Parser(lexer);
-    const ast = parser.parse();
+    const ast = parser.parse(false);
     const semAnalyzer = new SemanticAnalyzer(ast);
     const analyzedAst = semAnalyzer.analyze();
     const codeGen = new CodeGenerator(analyzedAst, semAnalyzer.defTypeMap);

--- a/cli.ts
+++ b/cli.ts
@@ -1,5 +1,12 @@
 import { parse } from "https://deno.land/std@0.204.0/flags/mod.ts";
-import { CodeGenerator, Lexer, Parser, SemanticAnalyzer, printCSrc } from "./mod.ts";
+import {
+  CodeGenerator,
+  Lexer,
+  Parser,
+  SemanticAnalyzer,
+  builtinDefTypeMap,
+  printCSrc
+} from "./mod.ts";
 
 if (import.meta.main) {
   const { _: [fileName_,], ...otherOptions } = parse(Deno.args);
@@ -12,9 +19,9 @@ if (import.meta.main) {
     const lexer = new Lexer(source);
     const parser = new Parser(lexer, fileName);
     const ast = parser.parse();
-    const semAnalyzer = new SemanticAnalyzer(ast);
+    const semAnalyzer = new SemanticAnalyzer(ast, builtinDefTypeMap());
     const analyzedAst = semAnalyzer.analyze();
-    const codeGen = new CodeGenerator(analyzedAst, semAnalyzer.defTypeMap);
+    const codeGen = new CodeGenerator(analyzedAst);
     const acir = codeGen.codegen();
 
     const optionCSourcePath_ = otherOptions["S"];

--- a/cli.ts
+++ b/cli.ts
@@ -10,9 +10,10 @@ if (import.meta.main) {
     const source = await Deno.readTextFile(fileName);
 
     const lexer = new Lexer(source);
-    const parser = new Parser(lexer);
-    const ast = parser.parse(false);
-    const semAnalyzer = new SemanticAnalyzer(ast);
+    const parser = new Parser(lexer, fileName);
+    const ast = parser.parse();
+    console.log(ast.name);
+    const semAnalyzer = new SemanticAnalyzer(ast.mod);
     const analyzedAst = semAnalyzer.analyze();
     const codeGen = new CodeGenerator(analyzedAst, semAnalyzer.defTypeMap);
     const acir = codeGen.codegen();

--- a/cli.ts
+++ b/cli.ts
@@ -12,8 +12,7 @@ if (import.meta.main) {
     const lexer = new Lexer(source);
     const parser = new Parser(lexer, fileName);
     const ast = parser.parse();
-    console.log(ast.name);
-    const semAnalyzer = new SemanticAnalyzer(ast.mod);
+    const semAnalyzer = new SemanticAnalyzer(ast);
     const analyzedAst = semAnalyzer.analyze();
     const codeGen = new CodeGenerator(analyzedAst, semAnalyzer.defTypeMap);
     const acir = codeGen.codegen();

--- a/examples/submodule.ajs
+++ b/examples/submodule.ajs
@@ -1,0 +1,18 @@
+module arith {
+    func add(a: i32, b: i32) -> i32 { a + b }
+    func sub(a: i32, b: i32) -> i32 { a - b }
+    func mul(a: i32, b: i32) -> i32 { a * b }
+    func div(a: i32, b: i32) -> i32 { a / b }
+
+    module deep_thought {
+        func answer() -> i32 { 42 }
+    }
+}
+
+func main() {
+    println_i32(arith::add(10, 5));
+    println_i32(arith::sub(10, 5));
+    println_i32(arith::mul(10, 5));
+    println_i32(arith::div(10, 5));
+    println_i32(arith::deep_thought::answer());
+}

--- a/mod.ts
+++ b/mod.ts
@@ -1,6 +1,6 @@
 export { Lexer } from "./src/lexer.ts";
 export { Parser } from "./src/parser.ts";
-export { SemanticAnalyzer } from "./src/semant.ts";
+export { SemanticAnalyzer, builtinDefTypeMap } from "./src/semant.ts";
 export type { DefTypeMap } from "./src/semant.ts";
 export { CodeGenerator } from "./src/codegen.ts";
 export { printCSrc } from "./src/c_src_printer.ts";

--- a/src/acir.ts
+++ b/src/acir.ts
@@ -12,9 +12,13 @@ export type ACDefInst = ACFuncDefInst | ACClosureDefInst;
 
 export type ACEntryInst = { inst: "entry", body: ACFuncBodyInst[] };
 
-export type ACFuncDeclInst = { inst: "func.decl", funcName: string, args: [string, Type][], resultType: Type };
+export type ACFuncDeclInst = {
+  inst: "func.decl", funcName: string, args: [string, Type][], resultType: Type,
+  modName: string
+};
 export type ACFuncDefInst = {
   inst: "func.def", funcName: string, args: [string, Type][], resultType: Type,
+  modName: string,
   envId: number,
   body: ACFuncBodyInst[]
 };
@@ -37,7 +41,7 @@ export type ACFuncBodyInst =
 
 export type ACEnvDefVarInst = { inst: "env.defvar", envId: number, varName: string, ty: Type, value: ACPushValInst };
 export type ACEnvLoadInst = { inst: "env.load", envId: number, varName: string };
-export type ACModDefsLoadInst = { inst: "mod_defs.load", varName: string };
+export type ACModDefsLoadInst = { inst: "mod_defs.load", modName: string, varName: string };
 export type ACBuiltinLoadInst = { inst: "builtin.load", varName: string };
 export type ACClosureLoadInst = { inst: "closure.load", id: string };
 
@@ -99,6 +103,6 @@ export type ACBoolOrInst = { inst: "bool.or", left: ACPushValInst, right: ACPush
 export type ACStrMakeStaticInst = { inst: "str.make_static", id: number, value: string, len: number };
 export type ACStrConstInst = { inst: "str.const", id: number };
 
-export type ACClosureMakeStaticInst = { inst: "closure.make_static", id: number, funcKind: FuncKind, name: string };
+export type ACClosureMakeStaticInst = { inst: "closure.make_static", id: number, funcKind: FuncKind, name: string, modName?: string };
 export type ACClosureConstInst = { inst: "closure.const", id: number };
 export type ACClosureMakeInst = { inst: "closure.make", id: number };

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -33,7 +33,7 @@ export type AstFuncArgNode = { nodeType: "funcArg", name: string, ty?: Type };
 
 export type AstLetNode = { nodeType: "let", declares: AstDeclareNode[], body: AstExprSeqNode, bodyTy?: Type, envId: number, rootIdx?: number, rootIndices?: number[] };
 
-export type AstDeclareNode = { nodeType: "declare", name: string, ty?: Type, value: AstExprNode };
+export type AstDeclareNode = { nodeType: "declare", name: string, ty?: Type, value: AstExprNode, modName?: string };
 
 export type AstIfNode = { nodeType: "if", cond: AstExprNode, then: AstExprSeqNode, else: AstExprSeqNode, ty?: Type };
 

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -49,5 +49,9 @@ export type AstUnitNode = { nodeType: "unit" };
 export type AstIntegerNode = { nodeType: "integer", value: number };
 export type AstStringLitNode = { nodeType: "string", value: string, len: number };
 export type AstBoolNode = { nodeType: "bool", value: boolean };
-export type AstVariableNode = { nodeType: "variable", name: string, level: number, fromEnv: number, toEnv: number, ty?: Type };
-export type AstPathNode = { nodeType: "path", sup: AstVariableNode, sub: AstPathNode | AstVariableNode };
+
+export type AstVariableNode = AstLocalVarNode | AstGlobalVarNode;
+export type AstLocalVarNode = { nodeType: "localVar", name: string, fromEnv: number, toEnv: number, ty?: Type };
+export type AstGlobalVarNode = { nodeType: "globalVar", name: string, modName?: string, ty?: Type };
+
+export type AstPathNode = { nodeType: "path", sup: string, sub: AstPathNode | AstGlobalVarNode };

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -1,18 +1,29 @@
 import { Type } from "./type.ts";
 
-export type AstNodeType =
-  "module"
-  | "def" | "func" | "funcArg" | "declare" | "if" | "let"
-  | "binary" | "unary" | "call" | "bool" | "integer" | "string" | "variable" | "unit";
+export type AstNodeType = AstNode["nodeType"];
 
 export type AstNode = AstModuleNode | AstDefNode | AstFuncArgNode | AstDeclareNode | AstExprNode;
 
 export type AstModuleNode = { nodeType: "module", defs: AstDefNode[] };
 
-export type AstDefNode = { nodeType: "def", declare: AstDeclareNode };
+export type AstDefNode = { nodeType: "def", declare: AstDeclareNode | AstModuleDeclareNode };
 
-export type AstExprNode = AstExprSeqNode |
-  AstFuncNode | AstIfNode | AstLetNode | AstCallNode | AstBinaryNode | AstUnaryNode | AstBoolNode | AstIntegerNode | AstStringLitNode | AstVariableNode | AstUnitNode;
+export type AstModuleDeclareNode = { nodeType: "moduleDeclare", name: string, mod: AstModuleNode };
+
+export type AstExprNode =
+  AstExprSeqNode
+  | AstFuncNode
+  | AstIfNode
+  | AstLetNode
+  | AstCallNode
+  | AstBinaryNode
+  | AstUnaryNode
+  | AstBoolNode
+  | AstIntegerNode
+  | AstStringLitNode
+  | AstVariableNode
+  | AstPathNode
+  | AstUnitNode;
 
 export type AstExprSeqNode = { nodeType: "exprSeq", exprs: AstExprNode[], ty?: Type };
 
@@ -39,3 +50,4 @@ export type AstIntegerNode = { nodeType: "integer", value: number };
 export type AstStringLitNode = { nodeType: "string", value: string, len: number };
 export type AstBoolNode = { nodeType: "bool", value: boolean };
 export type AstVariableNode = { nodeType: "variable", name: string, level: number, fromEnv: number, toEnv: number, ty?: Type };
+export type AstPathNode = { nodeType: "path", sup: AstVariableNode, sub: AstPathNode | AstVariableNode };

--- a/src/c_src_printer.ts
+++ b/src/c_src_printer.ts
@@ -40,7 +40,7 @@ export const printCSrc = async (filePath: string, module: ACModuleInst) => {
 };
 
 const printProtoType = async (writer: WritableStreamDefaultWriter, encoder: TextEncoder, decl: ACDeclInst) => {
-  let line = `${toCType(decl.resultType)} ${decl.inst === "func.decl" ? "userdef" : "closure"}_${decl.funcName}(AjisaiFuncFrame *parent_frame`;
+  let line = `${toCType(decl.resultType)} ${decl.inst === "func.decl" ? `userdef__${decl.modName}_` : "closure"}_${decl.funcName}(AjisaiFuncFrame *parent_frame`;
 
   for (const [argName, argTy] of decl.args) {
     line += `, ${toCType(argTy)} ${argName}`;
@@ -67,7 +67,7 @@ const printEntry = async (writer: WritableStreamDefaultWriter, encoder: TextEnco
 };
 
 const printFuncDef = async (writer: WritableStreamDefaultWriter, encoder: TextEncoder, def: ACDefInst) => {
-  let headLine = `${toCType(def.resultType)} ${def.inst === "func.def" ? "userdef" : "closure"}_${def.funcName}(AjisaiFuncFrame *parent_frame`;
+  let headLine = `${toCType(def.resultType)} ${def.inst === "func.def" ? `userdef__${def.modName}_` : "closure"}_${def.funcName}(AjisaiFuncFrame *parent_frame`;
   for (const [argName, argTy] of def.args) {
     headLine += `, ${toCType(argTy)} env${def.envId}_var_${argName}`;
   }
@@ -127,7 +127,7 @@ const printFuncBodyInst = async (writer: WritableStreamDefaultWriter, encoder: T
       line = `  static AjisaiString static_str${inst.id} = { .obj_header = { .tag = AJISAI_OBJ_STR }, .len = ${inst.len}, .value = ${inst.value} };\n  static_str${inst.id}.obj_header.type_info = ajisai_str_type_info();\n`;
       break;
     case "closure.make_static":
-      line = `  static AjisaiClosure static_closure${inst.id} = { .obj_header = { .tag = AJISAI_OBJ_FUNC }, .func_ptr = ${inst.funcKind === "builtin" ? "ajisai" : "userdef"}_${inst.name} };\n  static_closure${inst.id}.obj_header.type_info = ajisai_func_type_info();\n`;
+      line = `  static AjisaiClosure static_closure${inst.id} = { .obj_header = { .tag = AJISAI_OBJ_FUNC }, .func_ptr = ${inst.funcKind === "builtin" ? "ajisai" : `userdef__${inst.modName}_`}_${inst.name} };\n  static_closure${inst.id}.obj_header.type_info = ajisai_func_type_info();\n`;
       break;
     default:
       break;
@@ -141,7 +141,7 @@ const makePushValLiteral = (inst: ACPushValInst): string => {
     case "builtin.load":
       return `ajisai_${inst.varName}`;
     case "mod_defs.load":
-      return `userdef_${inst.varName}`;
+      return `userdef__${inst.modName}__${inst.varName}`;
     case "closure.load":
       return `closure_obj_${inst.id}`;
     case "env.load":

--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -46,6 +46,7 @@ export class CodeGenerator {
     let entry = undefined;
 
     for (const def of this.#module.defs) {
+      if (def.declare.nodeType === "moduleDeclare") throw new Error("not yet implemented");
       if (def.declare.ty!.tyKind === "func") {
         const funcCodeGen = new FuncCodeGenerator(def.declare.name, def.declare.ty!, def.declare.value as AstFuncNode);
         const [funcDecl, funcDef] = funcCodeGen.codegen(this.#defTypeMap);

--- a/src/env.ts
+++ b/src/env.ts
@@ -43,31 +43,35 @@ export class VarEnv {
     return this.#freshRootId;
   }
 
-  getVarTyAndLevel(name: string): { ty: Type, level: number, envId: number } | undefined {
+  getVarTy(name: string): { ty: Type, envKind: EnvKind, envId: number } | undefined {
     const ty_ = this.#variables.get(name);
     if (ty_) {
-      return { ty: ty_, level: 0, envId: this.envId };
+      return { ty: ty_, envKind: this.envKind, envId: this.envId };
     } else {
       if (this.parent_) {
-        const result = this.parent_.getVarTyAndLevel(name);
-        if (result) {
-          const { ty, level, envId } = result;
-          return { ty, level: level+1, envId };
-        }
+        return this.parent_.getVarTy(name);
       }
     }
     return undefined;
   }
 
-  setVarTy(name: string, ty: Type) {
+  setNewVarTy(name: string, ty: Type) {
     this.#variables.set(name, ty);
   }
 
-  setVarTyWithLevel(name: string, ty: Type, level: number) {
-    if (level === 0) {
-      this.setVarTy(name, ty);
+  setVarTy(name: string, ty: Type) {
+    if (this.#variables.get(name)) {
+      this.#variables.set(name, ty);
     } else {
-      this.parent_?.setVarTyWithLevel(name, ty, level-1);
+      this.parent_?.setVarTy(name, ty);
     }
   }
+
+  // setVarTyWithLevel(name: string, ty: Type, level: number) {
+  //   if (level === 0) {
+  //     this.setVarTy(name, ty);
+  //   } else {
+  //     this.parent_?.setVarTyWithLevel(name, ty, level-1);
+  //   }
+  // }
 }

--- a/src/env.ts
+++ b/src/env.ts
@@ -66,12 +66,4 @@ export class VarEnv {
       this.parent_?.setVarTy(name, ty);
     }
   }
-
-  // setVarTyWithLevel(name: string, ty: Type, level: number) {
-  //   if (level === 0) {
-  //     this.setVarTy(name, ty);
-  //   } else {
-  //     this.parent_?.setVarTyWithLevel(name, ty, level-1);
-  //   }
-  // }
 }

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -73,6 +73,10 @@ export class Lexer {
       case ",":
         return { tokenType: ",", value: "," };
       case ":":
+        if (this.peekChar() === ":") {
+          this.nextChar();
+          return { tokenType: "::", value: "::" };
+        }
         return { tokenType: ":", value: ":" };
       case ";":
         return { tokenType: ";", value: ";" };

--- a/src/token.ts
+++ b/src/token.ts
@@ -1,9 +1,9 @@
 export type TokenType =
   "+" | "-" | "*" | "/" | "%" | "=" | "==" | "!=" | "<" | "<=" | ">" | ">=" | "&&" | "||" | "!"
-  | "," | ":" | ";" | "|" | "(" | ")" | "{" | "}"
+  | "," | ":" | "::" | ";" | "|" | "(" | ")" | "{" | "}"
   | "->"
   | "true" | "false"
-  | "else" | "if" | "let" | "func" | "val"
+  | "else" | "if" | "let" | "func" | "val" | "module"
   | "identifier" | "integer" | "string"
   | "eof";
 
@@ -13,6 +13,6 @@ export type Token = Readonly<MutableToken>;
 export const printToken = (token: Token) => console.log(`Token { tokenType: ${token.tokenType}, value: ${token.value} }`);
 
 export type Keyword = Extract<TokenType, (typeof keywords)[number]>;
-const keywords = ["true", "false", "else", "if", "let", "func", "val"] as const;
+const keywords = ["true", "false", "else", "if", "let", "func", "val", "module"] as const;
 
 export const isKeyword = (s: string): Keyword | null => (keywords as Readonly<string[]>).includes(s) ? s as Keyword : null;

--- a/tests/lexer_test.ts
+++ b/tests/lexer_test.ts
@@ -132,3 +132,29 @@ Deno.test("lexing val statement test", () => {
     assertEquals(token, { tokenType, value });
   }
 });
+
+Deno.test("lexing module and symbol :: test", () => {
+  const src = `
+module deep_thought {
+  val answer: i32 = 42;
+}
+
+println_i32(deep_thought::answer);
+`;
+  const lexer = new Lexer(src);
+
+  const typeAndValues: [TokenType, string][] = [
+    ["module", "module"], ["identifier", "deep_thought"], ["{", "{"],
+    ["val", "val"], ["identifier", "answer"], [":", ":"], ["identifier", "i32"],
+    ["=", "="], ["integer", "42"], [";", ";"],
+    ["}", "}"],
+    ["identifier", "println_i32"], ["(", "("],
+    ["identifier", "deep_thought"], ["::", "::"], ["identifier", "answer"],
+    [")", ")"], [";", ";"]
+  ];
+
+  for (const [tokenType, value] of typeAndValues) {
+    const token = lexer.nextToken();
+    assertEquals(token, { tokenType, value });
+  }
+});

--- a/tests/parser_test.ts
+++ b/tests/parser_test.ts
@@ -4,7 +4,7 @@ import { Parser } from "../src/parser.ts";
 
 Deno.test("parsing integer node test", () => {
   const lexer = new Lexer("42");
-  const parser = new Parser(lexer);
+  const parser = new Parser(lexer, ".");
   const ast = parser.parseExpr();
 
   assertEquals(ast, { nodeType: "integer", value: 42 });
@@ -12,14 +12,14 @@ Deno.test("parsing integer node test", () => {
 
 Deno.test("parsing string node test", () => {
   const lexer = new Lexer('println_str("Hello, world!")');
-  const parser = new Parser(lexer);
+  const parser = new Parser(lexer, ".");
   const ast = parser.parseExpr();
 
   assertEquals(
     ast,
     {
       nodeType: "call",
-      callee: { nodeType: "variable", name: "println_str", level: -1, fromEnv: -1, toEnv: -1 },
+      callee: { nodeType: "localVar", name: "println_str", fromEnv: -1, toEnv: -1 },
       args: [
         { nodeType: "string", value: '"Hello, world!"', len: 0 }
       ]
@@ -29,7 +29,7 @@ Deno.test("parsing string node test", () => {
 
 Deno.test("parsing simple binary node test", () => {
   const lexer = new Lexer("1 + 2");
-  const parser = new Parser(lexer);
+  const parser = new Parser(lexer, ".");
   const ast = parser.parseExpr();
 
   assertEquals(
@@ -44,7 +44,7 @@ Deno.test("parsing simple binary node test", () => {
 
 Deno.test("parsing nested binary node test", () => {
   const lexer = new Lexer("2 * 3 + 4 - 5 / 6 % 7");
-  const parser = new Parser(lexer);
+  const parser = new Parser(lexer, ".");
   const ast = parser.parseExpr();
 
   assertEquals(
@@ -75,7 +75,7 @@ Deno.test("parsing nested binary node test", () => {
 
 Deno.test("parsing grouped binary node test", () => {
   const lexer = new Lexer("2 * (3 + 4) - 5 / (6 % 7)");
-  const parser = new Parser(lexer);
+  const parser = new Parser(lexer, ".");
   const ast = parser.parseExpr();
 
   assertEquals(
@@ -106,7 +106,7 @@ Deno.test("parsing grouped binary node test", () => {
 
 Deno.test("parsing let expression test", () => {
   const lexer = new Lexer("let val a = 1, val b = 2 { a + b }");
-  const parser = new Parser(lexer);
+  const parser = new Parser(lexer, ".");
   const ast = parser.parseExpr();
 
   assertEquals(
@@ -132,8 +132,8 @@ Deno.test("parsing let expression test", () => {
         exprs: [
           {
             nodeType: "binary", operator: "+",
-            left: { nodeType: "variable", name: "a", level: -1, fromEnv: -1, toEnv: -1 },
-            right: { nodeType: "variable", name: "b", level: -1, fromEnv: -1, toEnv: -1 }
+            left: { nodeType: "localVar", name: "a", fromEnv: -1, toEnv: -1 },
+            right: { nodeType: "localVar", name: "b", fromEnv: -1, toEnv: -1 }
           }
         ]
       },
@@ -144,7 +144,7 @@ Deno.test("parsing let expression test", () => {
 
 Deno.test("parsing if expression test", () => {
   const lexer = new Lexer("if a == 0 { 42 } else { a }");
-  const parser = new Parser(lexer);
+  const parser = new Parser(lexer, ".");
   const ast = parser.parseExpr();
 
   assertEquals(
@@ -153,18 +153,18 @@ Deno.test("parsing if expression test", () => {
       nodeType: "if",
       cond: {
         nodeType: "binary", operator: "==",
-        left: { nodeType: "variable", name: "a", level: -1, fromEnv: -1, toEnv: -1 },
+        left: { nodeType: "localVar", name: "a", fromEnv: -1, toEnv: -1 },
         right: { nodeType: "integer", value: 0 }
       },
       then: { nodeType: "exprSeq", exprs: [{ nodeType: "integer", value: 42 }] },
-      else: { nodeType: "exprSeq", exprs: [{ nodeType: "variable", name: "a", level: -1, fromEnv: -1, toEnv: -1 }] }
+      else: { nodeType: "exprSeq", exprs: [{ nodeType: "localVar", name: "a", fromEnv: -1, toEnv: -1 }] }
     }
   );
 });
 
 Deno.test("parsing 'else if' test", () => {
   const lexer = new Lexer("if a == 0 { 42 } else if a == 1 { -1 } else { a }");
-  const parser = new Parser(lexer);
+  const parser = new Parser(lexer, ".");
   const ast = parser.parseExpr();
 
   assertEquals(
@@ -173,7 +173,7 @@ Deno.test("parsing 'else if' test", () => {
       nodeType: "if",
       cond: {
         nodeType: "binary", operator: "==",
-        left: { nodeType: "variable", name: "a", level: -1, fromEnv: -1, toEnv: -1 },
+        left: { nodeType: "localVar", name: "a", fromEnv: -1, toEnv: -1 },
         right: { nodeType: "integer", value: 0 }
       },
       then: { nodeType: "exprSeq", exprs: [{ nodeType: "integer", value: 42 }] },
@@ -183,11 +183,11 @@ Deno.test("parsing 'else if' test", () => {
             nodeType: "if",
             cond: {
               nodeType: "binary", operator: "==",
-              left: { nodeType: "variable", name: "a", level: -1, fromEnv: -1, toEnv: -1 },
+              left: { nodeType: "localVar", name: "a", fromEnv: -1, toEnv: -1 },
               right: { nodeType: "integer", value: 1 }
             },
             then: { nodeType: "exprSeq", exprs: [{ nodeType: "unary", operator: "-", operand: { nodeType: "integer", value: 1 } }] },
-            else: { nodeType: "exprSeq", exprs: [{ nodeType: "variable", name: "a", level: -1, fromEnv: -1, toEnv: -1 }] }
+            else: { nodeType: "exprSeq", exprs: [{ nodeType: "localVar", name: "a", fromEnv: -1, toEnv: -1 }] }
           }
         ]
       }
@@ -197,8 +197,8 @@ Deno.test("parsing 'else if' test", () => {
 
 Deno.test("parsing func definition test", () => {
   const lexer = new Lexer("func add(a: i32, b: i32) -> i32 { a + b }");
-  const parser = new Parser(lexer);
-  const ast = parser.parse(false);
+  const parser = new Parser(lexer, ".");
+  const ast = parser.parse().mod;
 
   assertEquals(
     ast,
@@ -239,8 +239,8 @@ Deno.test("parsing func definition test", () => {
                 exprs: [
                   {
                     nodeType: "binary", operator: "+",
-                    left: { nodeType: "variable", name: "a", level: -1, fromEnv: -1, toEnv: -1 },
-                    right: { nodeType: "variable", name: "b", level: -1, fromEnv: -1, toEnv: -1 }
+                    left: { nodeType: "localVar", name: "a", fromEnv: -1, toEnv: -1 },
+                    right: { nodeType: "localVar", name: "b", fromEnv: -1, toEnv: -1 }
                   }
                 ]
               },
@@ -256,14 +256,14 @@ Deno.test("parsing func definition test", () => {
 
 Deno.test("parsing call expression test", () => {
   const lexer = new Lexer("println_i32(1 + 2)");
-  const parser = new Parser(lexer);
+  const parser = new Parser(lexer, ".");
   const ast = parser.parseExpr();
 
   assertEquals(
     ast,
     {
       nodeType: "call",
-      callee: { nodeType: "variable", name: "println_i32", level: -1, fromEnv: -1, toEnv: -1 },
+      callee: { nodeType: "localVar", name: "println_i32", fromEnv: -1, toEnv: -1 },
       args: [
         {
           nodeType: "binary", operator: "+",
@@ -277,8 +277,8 @@ Deno.test("parsing call expression test", () => {
 
 Deno.test("parsing empty main func test", () => {
   const lexer = new Lexer("func main() { () }");
-  const parser = new Parser(lexer);
-  const ast = parser.parse(false);
+  const parser = new Parser(lexer, ".");
+  const ast = parser.parse().mod;
 
   assertEquals(
     ast,
@@ -315,8 +315,8 @@ Deno.test("parsing empty main func test", () => {
 
 Deno.test("parsing func definition (with expression sequence) test", () => {
   const lexer = new Lexer("func add_with_display(a: i32, b: i32) -> i32 { println_i32(a + b); a + b }");
-  const parser = new Parser(lexer);
-  const ast = parser.parse(false);
+  const parser = new Parser(lexer, ".");
+  const ast = parser.parse().mod;
 
   assertEquals(
     ast,
@@ -357,19 +357,19 @@ Deno.test("parsing func definition (with expression sequence) test", () => {
                 exprs: [
                   {
                     nodeType: "call",
-                    callee: { nodeType: "variable", name: "println_i32", level: -1, fromEnv: -1, toEnv: -1 },
+                    callee: { nodeType: "localVar", name: "println_i32", fromEnv: -1, toEnv: -1 },
                     args: [
                       {
                         nodeType: "binary", operator: "+",
-                        left: { nodeType: "variable", name: "a", level: -1, fromEnv: -1, toEnv: -1 },
-                        right: { nodeType: "variable", name: "b", level: -1, fromEnv: -1, toEnv: -1 }
+                        left: { nodeType: "localVar", name: "a", fromEnv: -1, toEnv: -1 },
+                        right: { nodeType: "localVar", name: "b", fromEnv: -1, toEnv: -1 }
                       }
                     ]
                   },
                   {
                     nodeType: "binary", operator: "+",
-                    left: { nodeType: "variable", name: "a", level: -1, fromEnv: -1, toEnv: -1 },
-                    right: { nodeType: "variable", name: "b", level: -1, fromEnv: -1, toEnv: -1 }
+                    left: { nodeType: "localVar", name: "a", fromEnv: -1, toEnv: -1 },
+                    right: { nodeType: "localVar", name: "b", fromEnv: -1, toEnv: -1 }
                   }
                 ]
               },
@@ -385,7 +385,7 @@ Deno.test("parsing func definition (with expression sequence) test", () => {
 
 Deno.test("parsing func expression test", () => {
   const lexer = new Lexer("let val add = func(a: i32, b: i32) -> i32 { a + b } { add(1, 2) }");
-  const parser = new Parser(lexer);
+  const parser = new Parser(lexer, ".");
   const ast = parser.parseExpr();
 
   assertEquals(
@@ -409,8 +409,8 @@ Deno.test("parsing func expression test", () => {
                 {
                   nodeType: "binary",
                   operator: "+",
-                  left: { nodeType: "variable", name: "a", level: -1, fromEnv: -1, toEnv: -1 },
-                  right: { nodeType: "variable", name: "b", level: -1, fromEnv: -1, toEnv: -1 }
+                  left: { nodeType: "localVar", name: "a", fromEnv: -1, toEnv: -1 },
+                  right: { nodeType: "localVar", name: "b", fromEnv: -1, toEnv: -1 }
                 }
               ]
             },
@@ -424,7 +424,7 @@ Deno.test("parsing func expression test", () => {
         exprs: [
           {
             nodeType: "call",
-            callee: { nodeType: "variable", name: "add", level: -1, fromEnv: -1, toEnv: -1 },
+            callee: { nodeType: "localVar", name: "add", fromEnv: -1, toEnv: -1 },
             args: [
               { nodeType: "integer", value: 1 },
               { nodeType: "integer", value: 2 }
@@ -439,7 +439,7 @@ Deno.test("parsing func expression test", () => {
 
 Deno.test("parsing func expression (without arguments) test", () => {
   const lexer = new Lexer("let val hello = func() { println_str(\"Hello, world!\") } { hello() }");
-  const parser = new Parser(lexer);
+  const parser = new Parser(lexer, ".");
   const ast = parser.parseExpr();
 
   assertEquals(
@@ -459,7 +459,7 @@ Deno.test("parsing func expression (without arguments) test", () => {
               exprs: [
                 {
                   nodeType: "call",
-                  callee: { nodeType: "variable", name: "println_str", level: -1, fromEnv: -1, toEnv: -1 },
+                  callee: { nodeType: "localVar", name: "println_str", fromEnv: -1, toEnv: -1 },
                   args: [{ nodeType: "string", value: '"Hello, world!"', len: 0 }]
                 }
               ]
@@ -474,7 +474,7 @@ Deno.test("parsing func expression (without arguments) test", () => {
         exprs: [
           {
             nodeType: "call",
-            callee: { nodeType: "variable", name: "hello", level: -1, fromEnv: -1, toEnv: -1 },
+            callee: { nodeType: "localVar", name: "hello", fromEnv: -1, toEnv: -1 },
             args: []
           }
         ]
@@ -486,7 +486,7 @@ Deno.test("parsing func expression (without arguments) test", () => {
 
 Deno.test("parsing immediately invoked function test", () => {
   const lexer = new Lexer("func() { println_str(\"Hello, world!\") }()");
-  const parser = new Parser(lexer);
+  const parser = new Parser(lexer, ".");
   const ast = parser.parseExpr();
 
   assertEquals(
@@ -501,7 +501,7 @@ Deno.test("parsing immediately invoked function test", () => {
           exprs: [
             {
               nodeType: "call",
-              callee: { nodeType: "variable", name: "println_str", level: -1, fromEnv: -1, toEnv: -1 },
+              callee: { nodeType: "localVar", name: "println_str", fromEnv: -1, toEnv: -1 },
               args: [{ nodeType: "string", value: '"Hello, world!"', len: 0 }]
             }
           ]
@@ -516,8 +516,8 @@ Deno.test("parsing immediately invoked function test", () => {
 
 Deno.test("parsing val definition test", () => {
   const lexer = new Lexer("val a: i32 = 1 + 2;");
-  const parser = new Parser(lexer);
-  const ast = parser.parse(false);
+  const parser = new Parser(lexer, ".");
+  const ast = parser.parse().mod;
 
   assertEquals(
     ast,
@@ -549,8 +549,8 @@ Deno.test("parsing val definition test", () => {
 
 Deno.test("parsing empty main func (as val definition) test", () => {
   const lexer = new Lexer("val main: func() = func() { () };");
-  const parser = new Parser(lexer);
-  const ast = parser.parse(false);
+  const parser = new Parser(lexer, ".");
+  const ast = parser.parse().mod;
 
   assertEquals(
     ast,
@@ -592,7 +592,7 @@ let val hello = "hello "
     func display() { println_str(str_concat(hello, world)) }
 { display() }
 `);
-  const parser = new Parser(lexer);
+  const parser = new Parser(lexer, ".");
   const ast = parser.parseExpr();
 
   assertEquals(
@@ -629,14 +629,14 @@ let val hello = "hello "
               exprs: [
                 {
                   nodeType: "call",
-                  callee: { nodeType: "variable", name: "println_str", level: -1, fromEnv: -1, toEnv: -1 },
+                  callee: { nodeType: "localVar", name: "println_str", fromEnv: -1, toEnv: -1 },
                   args: [
                     {
                       nodeType: "call",
-                      callee: { nodeType: "variable", name: "str_concat", level: -1, fromEnv: -1, toEnv: -1 },
+                      callee: { nodeType: "localVar", name: "str_concat", fromEnv: -1, toEnv: -1 },
                       args: [
-                        { nodeType: "variable", name: "hello", level: -1, fromEnv: -1, toEnv: -1 },
-                        { nodeType: "variable", name: "world", level: -1, fromEnv: -1, toEnv: -1 }
+                        { nodeType: "localVar", name: "hello", fromEnv: -1, toEnv: -1 },
+                        { nodeType: "localVar", name: "world", fromEnv: -1, toEnv: -1 }
                       ]
                     }
                   ]
@@ -653,7 +653,7 @@ let val hello = "hello "
         exprs: [
           {
             nodeType: "call",
-            callee: { nodeType: "variable", name: "display", level: -1, fromEnv: -1, toEnv: -1 },
+            callee: { nodeType: "localVar", name: "display", fromEnv: -1, toEnv: -1 },
             args: []
           }
         ]
@@ -669,8 +669,8 @@ module deep_thought {
     val answer: i32 = 42;
 }
 `);
-  const parser = new Parser(lexer);
-  const ast = parser.parse(false);
+  const parser = new Parser(lexer, ".");
+  const ast = parser.parse().mod;
 
   assertEquals(
     ast,
@@ -705,7 +705,7 @@ module deep_thought {
 
 Deno.test("parsing module item access with path syntax test", () => {
   const lexer = new Lexer("!a::b::c::d || false");
-  const parser = new Parser(lexer);
+  const parser = new Parser(lexer, ".");
   const ast = parser.parseExpr();
 
   assertEquals(
@@ -718,14 +718,14 @@ Deno.test("parsing module item access with path syntax test", () => {
         operator: "!",
         operand: {
           nodeType: "path",
-          sup: { nodeType: "variable", name: "a", level: -1, fromEnv: -1, toEnv: -1 },
+          sup: "a",
           sub: {
             nodeType: "path",
-            sup: { nodeType: "variable", name: "b", level: -1, fromEnv: -1, toEnv: -1 },
+            sup: "b",
             sub: {
               nodeType: "path",
-              sup: { nodeType: "variable", name: "c", level: -1, fromEnv: -1, toEnv: -1 },
-              sub: { nodeType: "variable", name: "d", level: -1, fromEnv: -1, toEnv: -1 }
+              sup:"c",
+              sub: { nodeType: "globalVar", name: "d" }
             }
           }
         }


### PR DESCRIPTION
`module <module-name> { <module-item>... }` という形でサブモジュールを定義できるようにした。

モジュールアイテムへのアクセスには Rust のように `<module-name>::<module-item>` というようなパス関連記法を用いる。