### PR TITLE
import 文を追加

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -3,8 +3,7 @@ import {
   CodeGenerator,
   Lexer,
   Parser,
-  SemanticAnalyzer,
-  builtinDefTypeMap,
+  semanticAnalyze,
   printCSrc
 } from "./mod.ts";
 
@@ -19,8 +18,7 @@ if (import.meta.main) {
     const lexer = new Lexer(source);
     const parser = new Parser(lexer, fileName);
     const ast = parser.parse();
-    const semAnalyzer = new SemanticAnalyzer(ast, builtinDefTypeMap());
-    const analyzedAst = semAnalyzer.analyze();
+    const analyzedAst = semanticAnalyze(ast);
     const codeGen = new CodeGenerator(analyzedAst);
     const acir = codeGen.codegen();
 

--- a/examples/submodule.ajs
+++ b/examples/submodule.ajs
@@ -19,14 +19,20 @@ module a {
     }
 }
 
+import arith;
+import arith::deep_thought;
+import a as a1;
+import a::a as a2;
+import a::a::a as a3;
+
 func main() {
     println_i32(arith::add(10, 5));
     println_i32(arith::sub(10, 5));
     println_i32(arith::mul(10, 5));
     println_i32(arith::div(10, 5));
-    println_i32(arith::deep_thought::answer());
+    println_i32(deep_thought::answer());
 
-    println_str(a::hello());
-    println_str(a::a::hello());
-    println_str(a::a::a::hello());
+    println_str(a1::hello());
+    println_str(a2::hello());
+    println_str(a3::hello());
 }

--- a/examples/super_and_root_module.ajs
+++ b/examples/super_and_root_module.ajs
@@ -8,7 +8,7 @@ module a {
     }
 
     module c {
-        import root::d;
+        import package::d;
 
         func hello() {
             d::hello()

--- a/examples/super_and_root_module.ajs
+++ b/examples/super_and_root_module.ajs
@@ -1,0 +1,29 @@
+module a {
+    module b {
+        import super::c;
+
+        func hello() {
+            c::hello()
+        }
+    }
+
+    module c {
+        import root::d;
+
+        func hello() {
+            d::hello()
+        }
+    }
+}
+
+module d {
+    func hello() {
+        println_str("hello")
+    }
+}
+
+import a::b;
+
+func main() {
+    b::hello()
+}

--- a/mod.ts
+++ b/mod.ts
@@ -1,6 +1,6 @@
 export { Lexer } from "./src/lexer.ts";
 export { Parser } from "./src/parser.ts";
-export { SemanticAnalyzer, builtinDefTypeMap } from "./src/semant.ts";
+export { semanticAnalyze } from "./src/semant.ts";
 export type { DefTypeMap } from "./src/semant.ts";
 export { CodeGenerator } from "./src/codegen.ts";
 export { printCSrc } from "./src/c_src_printer.ts";

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -2,11 +2,23 @@ import { Type } from "./type.ts";
 
 export type AstNodeType = AstNode["nodeType"];
 
-export type AstNode = AstModuleNode | AstDefNode | AstFuncArgNode | AstDeclareNode | AstExprNode;
+export type AstNode =
+  AstModuleNode
+  | AstModuleItemNode
+  | AstFuncArgNode
+  | AstDeclareNode
+  | AstExprNode;
 
-export type AstModuleNode = { nodeType: "module", defs: AstDefNode[] };
+export type AstModuleNode = { nodeType: "module", items: AstModuleItemNode[] };
+export type AstModuleItemNode = AstDefNode | AstImportNode;
 
 export type AstDefNode = { nodeType: "def", declare: AstDeclareNode | AstModuleDeclareNode };
+
+export type AstImportNode = {
+  nodeType: "import",
+  path: AstPathNode | AstGlobalVarNode,
+  asName?: AstGlobalVarNode
+};
 
 export type AstModuleDeclareNode = { nodeType: "moduleDeclare", name: string, mod: AstModuleNode };
 

--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -43,21 +43,22 @@ export class CodeGenerator {
     let funcDefs: ACDefInst[] = [];
     let entry = undefined;
 
-    for (const def of this.#module.defs) {
-      if (def.declare.nodeType === "moduleDeclare") {
-        const codeGen = new CodeGenerator(def.declare.mod);
+    for (const item of this.#module.items) {
+      if (item.nodeType === "import") throw new Error("TODO");
+      if (item.declare.nodeType === "moduleDeclare") {
+        const codeGen = new CodeGenerator(item.declare.mod);
         const { funcDecls: subFuncDecls, funcDefs: subFuncDefs } = codeGen.codegen();
         funcDecls = subFuncDecls.concat(funcDecls);
         funcDefs = subFuncDefs.concat(funcDefs);
         continue;
       }
-      if (def.declare.value.nodeType === "func") {
-        if (def.declare.ty?.tyKind !== "func") throw new Error("unreachable");
+      if (item.declare.value.nodeType === "func") {
+        if (item.declare.ty?.tyKind !== "func") throw new Error("unreachable");
         const funcCodeGen = new FuncCodeGenerator(
-          def.declare.name,
-          def.declare.ty!,
-          def.declare.value as AstFuncNode,
-          def.declare.modName!
+          item.declare.name,
+          item.declare.ty!,
+          item.declare.value as AstFuncNode,
+          item.declare.modName!
         );
         const [funcDecl, funcDef] = funcCodeGen.codegen();
         if (funcDecl) funcDecls.push(funcDecl);

--- a/src/import_graph.ts
+++ b/src/import_graph.ts
@@ -1,0 +1,168 @@
+import {
+  AstModuleNode,
+  AstGlobalVarNode,
+  AstModuleDeclareNode,
+  AstPathNode,
+} from "./ast.ts";
+
+type VisitStatus = "unvisited" | "visiting" | "visited";
+
+type ModuleTreeNode = {
+  modName: { orig: string, renamed: string },
+  mod: AstModuleNode,
+  subMods: ModuleTreeNode[],
+  importPaths: { path: AstPathNode | AstGlobalVarNode, asName?: AstGlobalVarNode }[],
+  superMod: ModuleTreeNode | "root_module",
+  visitStatus: VisitStatus
+};
+
+class ModuleRenamer {
+  #prevModIdxs: Map<string, number> = new Map();
+
+  renameModule(name: string): string {
+    const idx = this.#prevModIdxs.get(name);
+    if (idx == null) {
+      this.#prevModIdxs.set(name, 0);
+      return `${name}0`;
+    } else  {
+      const nextIdx = idx + 1;
+      this.#prevModIdxs.set(name, nextIdx);
+      return `${name}${nextIdx}`;
+    }
+  }
+}
+
+const makeModuleTree = (
+  modDeclare: AstModuleDeclareNode,
+  superMod: ModuleTreeNode | "root_module",
+  modRenamer: ModuleRenamer
+): ModuleTreeNode => {
+  const { name, mod } = modDeclare;
+
+  const orig = name;
+  const renamed = modRenamer.renameModule(orig);
+
+  const moduleTree: ModuleTreeNode = {
+    modName: { orig, renamed },
+    mod,
+    subMods: [],
+    importPaths: [],
+    superMod,
+    visitStatus: "unvisited"
+  };
+
+  for (const item of mod.items) {
+    if (item.nodeType === "import") {
+      moduleTree.importPaths.push({
+        path: item.path,
+        asName: item.asName
+      });
+    } else if (item.nodeType === "def" && item.declare.nodeType === "moduleDeclare") {
+      moduleTree.subMods.push(makeModuleTree(
+        item.declare,
+        moduleTree,
+        modRenamer
+      ));
+    }
+  }
+
+  return moduleTree;
+};
+
+const resolvePath = (
+  modTree: ModuleTreeNode,
+  root: ModuleTreeNode,
+  path: AstPathNode | AstGlobalVarNode
+): ModuleTreeNode => {
+  if (path.nodeType === "globalVar") {
+    if (path.name === "root") {
+      // FIXME: path に親があったらこの結果は不自然
+      return root;
+    } else if (path.name === "super") {
+      const superMod = modTree.superMod;
+      if (superMod === "root_module") {
+        return root;
+      } else {
+        return superMod;
+      }
+    } else {
+      for (const subMod of modTree.subMods) {
+        if (subMod.modName.orig === path.name) {
+          return subMod;
+        }
+      }
+      throw new Error(`invalid module name: ${path.name}`);
+    }
+  } else {
+    const { sup, sub } = path;
+
+    let startNode: ModuleTreeNode | undefined = undefined;
+    if (sup === "root") {
+      startNode = root;
+    } else if (sup === "super") {
+      if (modTree.superMod === "root_module") {
+        startNode = root;
+      } else {
+        startNode = modTree.superMod;
+      }
+    } else {
+      for (const subMod of modTree.subMods) {
+        if (subMod.modName.orig === sup) {
+          startNode = subMod;
+          break;
+        }
+      }
+    }
+    if (startNode == null) throw new Error(`invalid module name: ${sup}`);
+
+    return resolvePath(startNode, root, sub);
+  }
+};
+
+export type ImportGraphNode = {
+  modName: { orig: string, renamed: string },
+  mod: AstModuleNode,
+  isAnalyzed: boolean,
+  importMods: Map<string, ImportGraphNode>,
+  importerMod?: ImportGraphNode,
+};
+
+const makeImportGraph1 = (
+  current: ModuleTreeNode,
+  root: ModuleTreeNode,
+  importerMod?: ImportGraphNode
+): ImportGraphNode => {
+  if (current.visitStatus === "visiting") {
+    throw new Error(`detect cycle import at ${current.modName.orig}`);
+  }
+
+  const graph: ImportGraphNode = {
+    modName: current.modName,
+    mod: current.mod,
+    isAnalyzed: false,
+    importMods: new Map(),
+    importerMod
+  };
+
+  current.visitStatus = "visiting";
+
+  for (const { path, asName } of current.importPaths) {
+    const importMod = makeImportGraph1(
+      resolvePath(current, root, path),
+      root,
+      graph
+    );
+    const modName = asName == null ? importMod.modName.orig : asName.name;
+    graph.importMods.set(modName, importMod);
+  }
+
+  current.visitStatus = "visited";
+
+  return graph;
+};
+
+export const makeImportGraph = (modDeclare: AstModuleDeclareNode): ImportGraphNode => {
+  const modRenamer = new ModuleRenamer();
+  const modTree = makeModuleTree(modDeclare, "root_module", modRenamer);
+  return makeImportGraph1(modTree, modTree);
+};

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -83,6 +83,16 @@ export class Parser {
       asName = { nodeType: "globalVar", name: asNameToken.value };
     }
     this.expect(";");
+
+    const modName = (() => {
+      let p = path;
+      while (p.nodeType === "path") p = p.sub;
+      return p.name;
+    })();
+    if (modName === "super" || modName === "package") {
+      asName = { nodeType: "globalVar", name: modName };
+    }
+
     return { nodeType: "import", path, asName };
   }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -15,6 +15,7 @@ import {
   AstGlobalVarNode,
   AstPathNode,
   AstModuleDeclareNode,
+  AstImportNode,
 } from "./ast.ts";
 import { Type, isPrimitiveTypeName } from "./type.ts";
 
@@ -39,30 +40,69 @@ export class Parser {
   }
 
   private parseModule(isSubMod: boolean): AstModuleNode {
-    const defs = [];
+    const items = [];
     while (!this.eat("eof")) {
       if (this.eat("val")) {
-        defs.push(this.parseValDef());
+        items.push(this.parseValDef());
       } else if (this.eat("func")) {
-        defs.push(this.parseFuncDef());
+        items.push(this.parseFuncDef());
       } else if (this.eat("module")) {
         const name = this.expect("identifier").value;
         this.expect("{");
         const mod = this.parseModule(true);
-        const def: AstDefNode = { nodeType: "def", declare: { nodeType: "moduleDeclare", name, mod } };
-        defs.push(def);
+        const def: AstDefNode = {
+          nodeType: "def",
+          declare: { nodeType: "moduleDeclare", name, mod }
+        };
+        items.push(def);
       } else if (this.eat("}")) {
         if (isSubMod) {
           break;
         } else {
           throw new Error("invalid token '}'");
         }
+      } else if (this.eat("import")) {
+        items.push(this.parseImport());
       } else {
         throw new Error("invalid definition");
       }
     }
 
-    return { nodeType: "module", defs };
+    return { nodeType: "module", items };
+  }
+
+  private parseImport(): AstImportNode {
+    const fst = this.expect("identifier");
+    let path: AstGlobalVarNode | AstPathNode = { nodeType: "globalVar", name: fst.value };
+    if (this.eat("::")) {
+      path = this.parsePath(path.name);
+    }
+    let asName: AstGlobalVarNode | undefined = undefined;
+    if (this.eat("as")) {
+      const asNameToken = this.expect("identifier");
+      asName = { nodeType: "globalVar", name: asNameToken.value };
+    }
+    this.expect(";");
+    return { nodeType: "import", path, asName };
+  }
+
+  private parsePath(firstName: string): AstPathNode {
+    const token = this.expect("identifier");
+    const sub: AstGlobalVarNode = { nodeType: "globalVar", name: token.value };
+    const expr: AstPathNode = { nodeType: "path", sup: firstName, sub };
+    let cur = expr;
+    while (this.eat("::")) {
+      const token = this.expect("identifier");
+      const sub: AstGlobalVarNode = { nodeType: "globalVar", name: token.value };
+      if (cur.sub.nodeType === "globalVar") {
+        const cur_sub: AstPathNode = { nodeType: "path", sup: cur.sub.name, sub }
+        cur.sub = cur_sub;
+        cur = cur_sub;
+      } else {
+        throw new Error("unreachable");
+      }
+    }
+    return expr;
   }
 
   private parseValDef(): AstDefNode {
@@ -416,66 +456,53 @@ export class Parser {
 
   private parsePrimary(): AstExprNode {
     let token;
+    let expr: AstExprNode | undefined = undefined;
 
     token = this.eat("true") ?? this.eat("false");
     if (token) {
-      return { nodeType: "bool", value: token.value == "true" };
+      expr = { nodeType: "bool", value: token.value == "true" };
     }
 
-    token = this.eat("string");
-    if (token) {
-      return { nodeType: "string", value: token.value, len: 0 };
+    if (expr == null) {
+      token = this.eat("string");
+      if (token) {
+        expr = { nodeType: "string", value: token.value, len: 0 };
+      }
     }
 
-    token = this.eat("integer");
-    if (token) {
-      return { nodeType: "integer", value: parseInt(token.value) };
+    if (expr == null) {
+      token = this.eat("integer");
+      if (token) {
+        expr = { nodeType: "integer", value: parseInt(token.value) };
+      }
     }
 
-    let expr: AstExprNode | undefined;
-
-    token = this.eat("(");
-    if (token) {
+    if (expr == null && this.eat("(")) {
       if (this.eat(")")) {
         return { nodeType: "unit" };
       }
       expr = this.parseGroup();
     }
 
-    token = this.eat("identifier");
-    if (token) {
-      expr = { nodeType: "localVar", name: token.value, fromEnv: -1, toEnv: -1 };
-      if (this.eat("::")) {
-        token = this.expect("identifier");
-        const sub: AstGlobalVarNode = { nodeType: "globalVar", name: token.value };
-        expr = { nodeType: "path", sup: expr.name, sub };
-        let cur = expr;
-        while (this.eat("::")) {
-          token = this.expect("identifier");
-          const sub: AstGlobalVarNode = { nodeType: "globalVar", name: token.value };
-          if (cur.sub.nodeType === "globalVar") {
-            const cur_sub: AstPathNode = { nodeType: "path", sup: cur.sub.name, sub }
-            cur.sub = cur_sub;
-            cur = cur_sub;
-          } else {
-            throw new Error("unreachable");
-          }
+    if (expr == null) {
+      token = this.eat("identifier");
+      if (token) {
+        expr = { nodeType: "localVar", name: token.value, fromEnv: -1, toEnv: -1 };
+        if (this.eat("::")) {
+          expr = this.parsePath(expr.name);
         }
       }
     }
 
-    token = this.eat("let");
-    if (token) {
+    if (expr == null && this.eat("let")) {
       expr = this.parseLet();
     }
 
-    token = this.eat("if");
-    if (token) {
+    if (expr == null && this.eat("if")) {
       expr = this.parseIf();
     }
 
-    token = this.eat("func");
-    if (token) {
+    if (expr == null && this.eat("func")) {
       expr = this.parseFunc();
     }
 

--- a/src/semant.ts
+++ b/src/semant.ts
@@ -147,9 +147,10 @@ export const builtinDefTypeMap = (): DefTypeMap => {
 
 const makeDefTypeMap = (module: AstModuleNode): DefTypeMap => {
   const defTypeMap = new Map();
-  for (const def of module.defs) {
-    if (def.declare.nodeType === "moduleDeclare") continue;
-    const { declare: { name, ty } } = def;
+  for (const item of module.items) {
+    if (item.nodeType === "import") continue;
+    if (item.declare.nodeType === "moduleDeclare") continue;
+    const { declare: { name, ty } } = item;
     if (ty) {
       defTypeMap.set(name, ty);
     } else {
@@ -220,13 +221,17 @@ export class SemanticAnalyzer {
   }
 
   analyze(): AstModuleNode {
-    const defs = this.#module.defs.map(def => this.analyzeDef(def));
+    const defs = this.#module.items.filter(
+      item => item.nodeType === "def"
+    ).map(
+      def => this.analyzeDef(def as AstDefNode)
+    );
     for (const def of this.#additional_defs) {
       if (def.declare.nodeType === "moduleDeclare") continue;
       this.defTypeMap.set(def.declare.name, def.declare.ty!);
       defs.push(def);
     }
-    return { nodeType: "module", defs };
+    return { nodeType: "module", items: defs };
   }
 
   private analyzeDef(ast: AstDefNode): AstDefNode {

--- a/src/semant.ts
+++ b/src/semant.ts
@@ -13,13 +13,12 @@ import {
   AstCallNode,
   AstExprSeqNode,
   AstModuleDeclareNode,
-  AstPathNode,
-  AstGlobalVarNode
 } from "./ast.ts";
+import { ImportGraphNode, makeImportGraph } from "./import_graph.ts";
 
 export type DefTypeMap = Map<string, Type>;
 
-export const builtinDefTypeMap = (): DefTypeMap => {
+const builtinDefTypeMap = (): DefTypeMap => {
   const defTypeMap = new Map();
   defTypeMap.set(
     "print_i32",
@@ -160,22 +159,6 @@ const makeDefTypeMap = (module: AstModuleNode): DefTypeMap => {
   return defTypeMap;
 };
 
-class ModuleRenamer {
-  #prevModIdxs: Map<string, number> = new Map();
-
-  renameModule(name: string): string {
-    const idx = this.#prevModIdxs.get(name);
-    if (idx == null) {
-      this.#prevModIdxs.set(name, 0);
-      return `${name}0`;
-    } else  {
-      const nextIdx = idx + 1;
-      this.#prevModIdxs.set(name, nextIdx);
-      return `${name}${nextIdx}`;
-    }
-  }
-}
-
 const getType = (name: string, defTypeMap: DefTypeMap, builtins?: DefTypeMap): Type | undefined => {
   const ty = defTypeMap.get(name);
   if (ty) {
@@ -185,50 +168,52 @@ const getType = (name: string, defTypeMap: DefTypeMap, builtins?: DefTypeMap): T
   }
 };
 
-export class SemanticAnalyzer {
+class SemanticAnalyzer {
   #builtins: DefTypeMap;
-  #module: AstModuleNode;
-  #modRenamer: ModuleRenamer;
-  modName: { orig: string, renamed: string };
+  #importGraph: ImportGraphNode;
   #additional_defs: AstDefNode[] = [];
   clsId: number;
-  defTypeMap: DefTypeMap;
-  subModAnalyzers: Map<string, SemanticAnalyzer> = new Map();
+  #defTypeMap: DefTypeMap;
 
   constructor(
-    modDeclare: AstModuleDeclareNode,
+    importGraph: ImportGraphNode,
     builtinDefTypeMap: DefTypeMap,
-    modRenamer?: ModuleRenamer,
     startClosureId?: number
   ) {
     this.#builtins = builtinDefTypeMap;
-    this.#module = modDeclare.mod;
-    if (modRenamer) {
-      this.#modRenamer = modRenamer;
-    } else {
-      this.#modRenamer = new ModuleRenamer();
-    }
+    this.#importGraph = importGraph;
     if (startClosureId) {
       this.clsId = startClosureId;
     } else {
       this.clsId = 0;
     }
-    this.modName = {
-      orig: modDeclare.name,
-      renamed: this.#modRenamer.renameModule(modDeclare.name)
-    };
-    this.defTypeMap = makeDefTypeMap(modDeclare.mod);
+    this.#defTypeMap = makeDefTypeMap(importGraph.mod);
   }
 
-  analyze(): AstModuleNode {
-    const defs = this.#module.items.filter(
-      item => item.nodeType === "def"
+  analyze(): ImportGraphNode {
+    for (const [asName, importGraph] of this.#importGraph.importMods.entries()) {
+      if (!importGraph.isAnalyzed) {
+        const analyzer = new SemanticAnalyzer(importGraph, this.#builtins, this.clsId);
+        const analyzedGraph = analyzer.analyze();
+        this.clsId = analyzer.clsId;
+        this.#importGraph.importMods.set(asName, analyzedGraph);
+      }
+    }
+    const analyzedMod = this.analyzeModule(this.#importGraph.mod);
+    this.#importGraph.mod = analyzedMod;
+    this.#importGraph.isAnalyzed = true;
+    return this.#importGraph;
+  }
+
+  private analyzeModule(ast: AstModuleNode): AstModuleNode {
+    const defs = ast.items.filter(
+      item => item.nodeType === "def" && item.declare.nodeType !== "moduleDeclare"
     ).map(
       def => this.analyzeDef(def as AstDefNode)
     );
     for (const def of this.#additional_defs) {
-      if (def.declare.nodeType === "moduleDeclare") continue;
-      this.defTypeMap.set(def.declare.name, def.declare.ty!);
+      if (def.declare.nodeType === "moduleDeclare") throw new Error("unreachable");
+      this.#defTypeMap.set(def.declare.name, def.declare.ty!);
       defs.push(def);
     }
     return { nodeType: "module", items: defs };
@@ -248,7 +233,7 @@ export class SemanticAnalyzer {
               name: ast.declare.name,
               ty: ast.declare.ty,
               value: exprNode,
-              modName: this.modName.renamed
+              modName: this.#importGraph.modName.renamed
             }
           };
         } else {
@@ -260,18 +245,7 @@ export class SemanticAnalyzer {
       }
     }
     if (ast.declare.nodeType === "moduleDeclare") {
-      const subModAnalyzer = new SemanticAnalyzer(ast.declare, this.#builtins, this.#modRenamer, this.clsId);
-      const mod = subModAnalyzer.analyze();
-      this.clsId = subModAnalyzer.clsId;
-      this.subModAnalyzers.set(subModAnalyzer.modName.orig, subModAnalyzer);
-      return {
-        nodeType: "def",
-        declare: {
-          nodeType: "moduleDeclare",
-          name: subModAnalyzer.modName.renamed,
-          mod
-        }
-      };
+      throw new Error("unreachable");
     }
     throw new Error("not yet implemented");
   }
@@ -324,33 +298,39 @@ export class SemanticAnalyzer {
         }
         astTy = ty;
       } else {
-        const ty = getType(ast.name, this.defTypeMap, this.#builtins);
+        const ty = getType(ast.name, this.#defTypeMap, this.#builtins);
         if (ty) {
           return [
             // TODO: modName も指定する
-            { nodeType: "globalVar", name: ast.name, ty, modName: this.modName.renamed },
+            {
+              nodeType: "globalVar",
+              name: ast.name,
+              ty,
+              modName: this.#importGraph.modName.renamed
+            },
             ty
           ];
         }
         throw new Error(`variable not found: ${ast.name}`);
       }
     } else if (ast.nodeType === "path") {
-      let modName = ast.sup;
-      let mod: SemanticAnalyzer | undefined = this.subModAnalyzers.get(modName);
-      let node: AstPathNode | AstGlobalVarNode = ast.sub;
-      while (node.nodeType === "path") {
-        if (mod == null) throw new Error(`invalid module name: ${modName}`);
-        modName = node.sup;
-        mod = mod.subModAnalyzers.get(modName);
-        node = node.sub;
+      const modName = ast.sup;
+      const modGraph = this.#importGraph.importMods.get(modName);
+      if (modGraph == null) throw new Error(`invalid module name: ${modName}`);
+      if (ast.sub.nodeType === "path") {
+        throw new Error("cannot nested module access");
       }
-      if (mod == null) throw new Error(`invalid module name: ${modName}`);
-      const ty = mod.defTypeMap.get(node.name);
-      if (ty == null) throw new Error(`variable '${node.name}' not found in module '${modName}'`);
+      let ty: Type | undefined = undefined;
+      for (const item of modGraph.mod.items) {
+        if (item.nodeType === "def" && item.declare.nodeType !== "moduleDeclare") {
+          ty = item.declare.ty;
+        }
+      }
+      if (ty == null) throw new Error(`variable '${ast.sub.name}' not found in module '${modName}'`);
       astTy = ty;
-      node.ty = ty;
-      node.modName = mod.modName.renamed;
-      ast = node;
+      ast.sub.ty = ty;
+      ast.sub.modName = modGraph.modName.renamed;
+      ast = ast.sub;
     } else if (ast.nodeType === "integer") {
       astTy = { tyKind: "primitive", name: "i32" } as PrimitiveType;
     } else if (ast.nodeType === "bool") {
@@ -603,3 +583,9 @@ export class SemanticAnalyzer {
     throw new Error("invalid unary node type");
   }
 }
+
+export const semanticAnalyze = (modDeclare: AstModuleDeclareNode): ImportGraphNode => {
+  const importGraph = makeImportGraph(modDeclare);
+  const semAnalyzer = new SemanticAnalyzer(importGraph, builtinDefTypeMap());
+  return semAnalyzer.analyze();
+};

--- a/src/token.ts
+++ b/src/token.ts
@@ -3,7 +3,8 @@ export type TokenType =
   | "," | ":" | "::" | ";" | "|" | "(" | ")" | "{" | "}"
   | "->"
   | "true" | "false"
-  | "else" | "if" | "let" | "func" | "val" | "module"
+  | "else" | "if" | "let" | "func" | "val" | "module" | "import"
+  | "as"
   | "identifier" | "integer" | "string"
   | "eof";
 
@@ -13,6 +14,17 @@ export type Token = Readonly<MutableToken>;
 export const printToken = (token: Token) => console.log(`Token { tokenType: ${token.tokenType}, value: ${token.value} }`);
 
 export type Keyword = Extract<TokenType, (typeof keywords)[number]>;
-const keywords = ["true", "false", "else", "if", "let", "func", "val", "module"] as const;
+const keywords = [
+  "true",
+  "false",
+  "else",
+  "if",
+  "let",
+  "func",
+  "val",
+  "module",
+  "import",
+  "as"
+] as const;
 
 export const isKeyword = (s: string): Keyword | null => (keywords as Readonly<string[]>).includes(s) ? s as Keyword : null;

--- a/tests/parser_test.ts
+++ b/tests/parser_test.ts
@@ -204,7 +204,7 @@ Deno.test("parsing func definition test", () => {
     ast,
     {
       nodeType: "module",
-      defs: [
+      items: [
         {
           nodeType: "def",
           declare: {
@@ -284,7 +284,7 @@ Deno.test("parsing empty main func test", () => {
     ast,
     {
       nodeType: "module",
-      defs: [
+      items: [
         {
           nodeType: "def",
           declare: {
@@ -322,7 +322,7 @@ Deno.test("parsing func definition (with expression sequence) test", () => {
     ast,
     {
       nodeType: "module",
-      defs: [
+      items: [
         {
           nodeType: "def",
           declare: {
@@ -523,7 +523,7 @@ Deno.test("parsing val definition test", () => {
     ast,
     {
       nodeType: "module",
-      defs: [
+      items: [
         {
           nodeType: "def",
           declare: {
@@ -556,7 +556,7 @@ Deno.test("parsing empty main func (as val definition) test", () => {
     ast,
     {
       nodeType: "module",
-      defs: [
+      items: [
         {
           nodeType: "def",
           declare: {
@@ -676,7 +676,7 @@ module deep_thought {
     ast,
     {
       nodeType: "module",
-      defs: [
+      items: [
         {
           nodeType: "def",
           declare: {
@@ -684,7 +684,7 @@ module deep_thought {
             name: "deep_thought",
             mod: {
               nodeType: "module",
-              defs: [
+              items: [
                 {
                   nodeType: "def",
                   declare: {
@@ -704,7 +704,7 @@ module deep_thought {
 });
 
 Deno.test("parsing module item access with path syntax test", () => {
-  const lexer = new Lexer("!a::b::c::d || false");
+  const lexer = new Lexer("!a::b || false");
   const parser = new Parser(lexer, ".");
   const ast = parser.parseExpr();
 
@@ -719,18 +719,54 @@ Deno.test("parsing module item access with path syntax test", () => {
         operand: {
           nodeType: "path",
           sup: "a",
-          sub: {
-            nodeType: "path",
-            sup: "b",
-            sub: {
-              nodeType: "path",
-              sup:"c",
-              sub: { nodeType: "globalVar", name: "d" }
-            }
-          }
+          sub: { nodeType: "globalVar", name: "b" }
         }
       },
       right: { nodeType: "bool", value: false }
+    }
+  );
+});
+
+Deno.test("parsing import statement test", () => {
+  const lexer = new Lexer("import a::b::c; import d::e::f as hello;");
+  const parser = new Parser(lexer, ".");
+  const ast = parser.parse().mod;
+
+  assertEquals(
+    ast,
+    {
+      nodeType: "module",
+      items: [
+        {
+          nodeType: "import",
+          path: {
+            nodeType: "path",
+            sup: "a",
+            sub: {
+              nodeType: "path",
+              sup: "b",
+              sub: { nodeType: "globalVar", name: "c" }
+            }
+          },
+          asName: undefined
+        },
+        {
+          nodeType: "import",
+          path: {
+            nodeType: "path",
+            sup: "d",
+            sub: {
+              nodeType: "path",
+              sup: "e",
+              sub: { nodeType: "globalVar", name: "f" }
+            }
+          },
+          asName: {
+            nodeType: "globalVar",
+            name: "hello"
+          }
+        }
+      ]
     }
   );
 });


### PR DESCRIPTION
あるモジュールから他のモジュールにアクセスするのに、import 文による指定を必須にする。
循環インポートは許可しない。
特殊なモジュール名として、

- `super`: 現在のモジュールから構文的に見て１つ上の階層のモジュールを指す名前
- `package`: モジュールツリーのルートに位置するモジュールを指す名前

を用意している。