### PR TITLE
モジュールのトップレベルに式文を書けるようにする

### DIFF
--- a/examples/def_and_call_func.ajs
+++ b/examples/def_and_call_func.ajs
@@ -16,3 +16,5 @@ func main() {
         println_i32(add(a, b))
     }
 }
+
+main();

--- a/examples/exprseq.ajs
+++ b/examples/exprseq.ajs
@@ -11,6 +11,4 @@ func countup_inner(x: i32, until: i32) {
     }
 }
 
-func main() {
-    countup(10)
-}
+countup(10);

--- a/examples/fizzbuzz.ajs
+++ b/examples/fizzbuzz.ajs
@@ -19,6 +19,4 @@ func fizzbuzz_iter(cur: i32, end: i32) {
     }
 }
 
-func main() {
-    fizzbuzz(1, 100)
-}
+fizzbuzz(1, 100);

--- a/examples/higher_order_function.ajs
+++ b/examples/higher_order_function.ajs
@@ -23,3 +23,5 @@ func main() {
         print_func_result(a, b, div_func)
     }
 }
+
+main();

--- a/examples/higher_order_function.ajs
+++ b/examples/higher_order_function.ajs
@@ -1,9 +1,9 @@
-func print_func_result(a: i32, b: i32, p: func(i32, i32) -> i32) {
+func print_func_result(a: i32, b: i32, p: fn(i32, i32) -> i32) {
     println_i32(p(a, b))
 }
 
-func get_sub_func() -> func(i32, i32) -> i32 {
-    func(a: i32, b: i32) -> i32 { a - b }
+func get_sub_func() -> fn(i32, i32) -> i32 {
+    fn(a: i32, b: i32) -> i32 { a - b }
 }
 
 func div_func(a: i32, b: i32) -> i32 {

--- a/examples/immediately_invoked_function.ajs
+++ b/examples/immediately_invoked_function.ajs
@@ -1,3 +1,1 @@
-func main() {
-    func() { println_str("hello!") }()
-}
+func() { println_str("hello!") }();

--- a/examples/immediately_invoked_function.ajs
+++ b/examples/immediately_invoked_function.ajs
@@ -1,1 +1,1 @@
-func() { println_str("hello!") }();
+fn() { println_str("hello!") }();

--- a/examples/local_func.ajs
+++ b/examples/local_func.ajs
@@ -1,6 +1,4 @@
-func main() {
-    let func concat(a: str, b: str) -> str { str_concat(a, b) }
-    {
-        println_str(concat("Hello, ", "world!"))
-    }
-}
+let func concat(a: str, b: str) -> str { str_concat(a, b) }
+{
+    println_str(concat("Hello, ", "world!"))
+};

--- a/examples/main_with_val.ajs
+++ b/examples/main_with_val.ajs
@@ -1,4 +1,4 @@
-val main: func() = func() {
+val main: fn() = fn() {
     println_str("hello!")
 };
 

--- a/examples/main_with_val.ajs
+++ b/examples/main_with_val.ajs
@@ -1,3 +1,5 @@
 val main: func() = func() {
     println_str("hello!")
 };
+
+main();

--- a/examples/manual_gc.ajs
+++ b/examples/manual_gc.ajs
@@ -14,3 +14,5 @@ func main() {
     gc_start();
     print_repeated_str("Piyo", 4)
 }
+
+main();

--- a/examples/module_level_expr_stmt.ajs
+++ b/examples/module_level_expr_stmt.ajs
@@ -1,0 +1,7 @@
+module hoge {
+    println_str("hoge");
+}
+
+import hoge;
+
+println_str("fuga");

--- a/examples/module_level_func_as_object.ajs
+++ b/examples/module_level_func_as_object.ajs
@@ -13,3 +13,5 @@ func main() {
         three(10)
     }
 }
+
+main();

--- a/examples/module_level_func_as_object.ajs
+++ b/examples/module_level_func_as_object.ajs
@@ -6,7 +6,7 @@ func main() {
     let
         val one = println_i32
         val two = test_userdef
-        val three = func(n: i32) { println_i32(n * 3) }
+        val three = fn(n: i32) { println_i32(n * 3) }
     {
         one(10);
         two(10);

--- a/examples/nested_func_literal.ajs
+++ b/examples/nested_func_literal.ajs
@@ -1,20 +1,18 @@
-func main() {
-    let val t0 = func() {
-        println_str("t0 start");
-        let val t1 = func() {
-            println_str("t1 start");
-            let val t2 = func() {
-                println_str("t2 start");
-                println_str("t2 end")
-            } {
-                t2()
-            };
-            println_str("t1 end")
+let val t0 = func() {
+    println_str("t0 start");
+    let val t1 = func() {
+        println_str("t1 start");
+        let val t2 = func() {
+            println_str("t2 start");
+            println_str("t2 end")
         } {
-            t1()
+            t2()
         };
-        println_str("t0 end")
+        println_str("t1 end")
     } {
-        t0()
-    }
-}
+        t1()
+    };
+    println_str("t0 end")
+} {
+    t0()
+};

--- a/examples/nested_func_literal.ajs
+++ b/examples/nested_func_literal.ajs
@@ -1,8 +1,8 @@
-let val t0 = func() {
+let val t0 = fn() {
     println_str("t0 start");
-    let val t1 = func() {
+    let val t1 = fn() {
         println_str("t1 start");
-        let val t2 = func() {
+        let val t2 = fn() {
             println_str("t2 start");
             println_str("t2 end")
         } {

--- a/examples/nested_let.ajs
+++ b/examples/nested_let.ajs
@@ -1,7 +1,5 @@
-func main() {
-    let val a = 2
-        val b = let { 3 + a }
-    {
-        println_i32(let val c = b * 3 { c + 10 })
-    }
-}
+let val a = 2
+    val b = let { 3 + a }
+{
+    println_i32(let val c = b * 3 { c + 10 })
+};

--- a/examples/nested_let_and_if.ajs
+++ b/examples/nested_let_and_if.ajs
@@ -1,13 +1,11 @@
-func main() {
-    println_i32(
-        let val a = 3
-            val b = if a == 2 { 2 } else { 5 }
-        {
-            if a != 1 {
-                let val c = b { c }
-            } else {
-                42
-            }
+println_i32(
+    let val a = 3
+        val b = if a == 2 { 2 } else { 5 }
+    {
+        if a != 1 {
+            let val c = b { c }
+        } else {
+            42
         }
-    )
-}
+    }
+);

--- a/examples/rec_func.ajs
+++ b/examples/rec_func.ajs
@@ -10,4 +10,4 @@ func factorial_inner(accum: i32, x: i32) -> i32 {
     }
 }
 
-func main() { println_i32(factorial(10)) }
+println_i32(factorial(10));

--- a/examples/simple_equality.ajs
+++ b/examples/simple_equality.ajs
@@ -1,3 +1,1 @@
-func main() {
-    println_bool(1 == 1)
-}
+println_bool(1 == 1);

--- a/examples/some_arg_types.ajs
+++ b/examples/some_arg_types.ajs
@@ -6,6 +6,4 @@ func select_print(left: i32, right: i32, select_left: bool) {
     }
 }
 
-func main() {
-    select_print(1, 2, true)
-}
+select_print(1, 2, true);

--- a/examples/str_functions.ajs
+++ b/examples/str_functions.ajs
@@ -10,6 +10,4 @@ func print_equal(src: str, value: str, count: i32, end: i32) {
     }
 }
 
-func main() {
-    print_equal("Hoge", "HogeHogeHogeHoge", 0, 10)
-}
+print_equal("Hoge", "HogeHogeHogeHoge", 0, 10);

--- a/examples/submodule.ajs
+++ b/examples/submodule.ajs
@@ -36,3 +36,5 @@ func main() {
     println_str(a2::hello());
     println_str(a3::hello());
 }
+
+main();

--- a/examples/super_and_root_module.ajs
+++ b/examples/super_and_root_module.ajs
@@ -24,6 +24,4 @@ module d {
 
 import a::b;
 
-func main() {
-    b::hello()
-}
+b::hello();

--- a/src/acir.ts
+++ b/src/acir.ts
@@ -12,8 +12,9 @@ export type ACDeclInst = ACFuncDeclInst | ACClosureDeclInst;
 export type ACDefInst = ACFuncDefInst | ACClosureDefInst;
 
 // export type ACEntryInst = { inst: "entry", body: ACFuncBodyInst[] };
-// FIXME: body の要素は ACFuncDefInst ではない。モジュールレベル変数の初期化命令も必要になるため。
-export type ACModInitDefInst = { inst: "mod_init.def" , body: ACFuncBodyInst[], modName: string };
+export type ACModInitBodyInst = ACFuncBodyInst | ACModInitInst;
+export type ACModInitInst = { inst: "mod.init", modName: string };
+export type ACModInitDefInst = { inst: "mod_init.def" , body: ACModInitBodyInst[], modName: string };
 
 export type ACFuncDeclInst = {
   inst: "func.decl", funcName: string, args: [string, Type][], resultType: Type,

--- a/src/acir.ts
+++ b/src/acir.ts
@@ -4,13 +4,16 @@ export type ACModuleInst = {
   inst: "module",
   funcDecls: ACDeclInst[],
   funcDefs: ACDefInst[],
-  entry?: ACEntryInst
+  modInits: ACModInitDefInst[],
+  entryModName: string,
 };
 
 export type ACDeclInst = ACFuncDeclInst | ACClosureDeclInst;
 export type ACDefInst = ACFuncDefInst | ACClosureDefInst;
 
-export type ACEntryInst = { inst: "entry", body: ACFuncBodyInst[] };
+// export type ACEntryInst = { inst: "entry", body: ACFuncBodyInst[] };
+// FIXME: body の要素は ACFuncDefInst ではない。モジュールレベル変数の初期化命令も必要になるため。
+export type ACModInitDefInst = { inst: "mod_init.def" , body: ACFuncBodyInst[], modName: string };
 
 export type ACFuncDeclInst = {
   inst: "func.decl", funcName: string, args: [string, Type][], resultType: Type,

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -9,8 +9,8 @@ export type AstNode =
   | AstDeclareNode
   | AstExprNode;
 
-export type AstModuleNode = { nodeType: "module", items: AstModuleItemNode[] };
-export type AstModuleItemNode = AstDefNode | AstImportNode;
+export type AstModuleNode = { nodeType: "module", items: AstModuleItemNode[], envId: number, rootTableSize?: number };
+export type AstModuleItemNode = AstDefNode | AstImportNode | AstExprStmtNode;
 
 export type AstDefNode = { nodeType: "def", declare: AstDeclareNode | AstModuleDeclareNode };
 
@@ -21,6 +21,8 @@ export type AstImportNode = {
 };
 
 export type AstModuleDeclareNode = { nodeType: "moduleDeclare", name: string, mod: AstModuleNode };
+
+export type AstExprStmtNode = { nodeType: "exprStmt", expr: AstExprNode };
 
 export type AstExprNode =
   AstExprSeqNode

--- a/src/c_src_printer.ts
+++ b/src/c_src_printer.ts
@@ -54,9 +54,9 @@ const printMain = async (writer: WritableStreamDefaultWriter, encoder: TextEncod
   await writer.write(encoder.encode("  AjisaiMemManager mem_manager;\n"));
   // TODO: メモリ確保に失敗した時に終了する処理を入れる
   await writer.write(encoder.encode("  ajisai_mem_manager_init(&mem_manager);\n"));
-  await writer.write(encoder.encode("  AjisaiFuncFrame *func_frame = &(AjisaiFuncFrame){ .parent = NULL, .mem_manager = &mem_manager };\n"));
+  await writer.write(encoder.encode("  AjisaiFuncFrame func_frame = { .parent = NULL, .mem_manager = &mem_manager };\n"));
 
-  await writer.write(encoder.encode(`  modinit__${entryModName}(func_frame);\n`));
+  await writer.write(encoder.encode(`  modinit__${entryModName}(&func_frame);\n`));
 
   await writer.write(encoder.encode("  ajisai_mem_manager_deinit(&mem_manager);\n"));
   await writer.write(encoder.encode("  return 0;\n"));
@@ -69,7 +69,11 @@ const printModInitDef = async (writer: WritableStreamDefaultWriter, encoder: Tex
   await writer.write(encoder.encode("  if (!is_initialized) {\n"));
 
   for (const inst of modInit.body) {
-    await printFuncBodyInst(writer, encoder, inst);
+    if (inst.inst === "mod.init") {
+      await writer.write(encoder.encode(`  modinit__${inst.modName}(&func_frame);\n`));
+    } else {
+      await printFuncBodyInst(writer, encoder, inst);
+    }
   }
 
   await writer.write(encoder.encode("  is_initialized = true;\n"));

--- a/src/c_src_printer.ts
+++ b/src/c_src_printer.ts
@@ -1,13 +1,7 @@
-import { ACEntryInst, ACIfElseInst, ACModuleInst, ACFuncBodyInst, ACDeclInst, ACDefInst, ACPushValInst } from "./acir.ts";
+import { ACIfElseInst, ACModuleInst, ACFuncBodyInst, ACDeclInst, ACDefInst, ACPushValInst, ACModInitDefInst } from "./acir.ts";
 import { toCType } from "./type.ts";
 
 const defaultFileHeader = "#include <ajisai_runtime.h>\n\n";
-
-const cMain = `int main(void) {
-  ajisai_main();
-  return 0;
-}
-`;
 
 export const printCSrc = async (filePath: string, module: ACModuleInst) => {
   const file = await Deno.open(filePath, { write: true, create: true, truncate: true });
@@ -22,18 +16,22 @@ export const printCSrc = async (filePath: string, module: ACModuleInst) => {
       await printProtoType(writer, encoder, funcDecl);
     }
 
+    for (const modInit of module.modInits) {
+      await writer.write(encoder.encode(`void modinit__${modInit.modName}(AjisaiFuncFrame *parent_frame);\n`));
+    }
+
     for (const funcDef of module.funcDefs) {
       await writer.write(encoder.encode("\n"));
       await printFuncDef(writer, encoder, funcDef);
     }
 
-    if (module.entry) {
+    for (const modInit of module.modInits) {
       await writer.write(encoder.encode("\n"));
-      await printEntry(writer, encoder, module.entry);
-
-      await writer.write(encoder.encode("\n"));
-      await writer.write(encoder.encode(cMain));
+      await printModInitDef(writer, encoder, modInit);
     }
+
+    await writer.write(encoder.encode("\n"));
+    await printMain(writer, encoder, module.entryModName);
   } finally {
     file.close();
   }
@@ -51,20 +49,34 @@ const printProtoType = async (writer: WritableStreamDefaultWriter, encoder: Text
   await writer.write(encoder.encode(line));
 };
 
-const printEntry = async (writer: WritableStreamDefaultWriter, encoder: TextEncoder, entry: ACEntryInst) => {
-  await writer.write(encoder.encode("void ajisai_main(void) {\n"));
+const printMain = async (writer: WritableStreamDefaultWriter, encoder: TextEncoder, entryModName: string) => {
+  await writer.write(encoder.encode("int main() {\n"));
   await writer.write(encoder.encode("  AjisaiMemManager mem_manager;\n"));
   // TODO: メモリ確保に失敗した時に終了する処理を入れる
   await writer.write(encoder.encode("  ajisai_mem_manager_init(&mem_manager);\n"));
-  await writer.write(encoder.encode("  AjisaiFuncFrame *parent_frame = &(AjisaiFuncFrame){ .parent = NULL, .mem_manager = &mem_manager };\n"));
+  await writer.write(encoder.encode("  AjisaiFuncFrame *func_frame = &(AjisaiFuncFrame){ .parent = NULL, .mem_manager = &mem_manager };\n"));
 
-  for (const inst of entry.body) {
+  await writer.write(encoder.encode(`  modinit__${entryModName}(func_frame);\n`));
+
+  await writer.write(encoder.encode("  ajisai_mem_manager_deinit(&mem_manager);\n"));
+  await writer.write(encoder.encode("  return 0;\n"));
+  await writer.write(encoder.encode("}\n"));
+};
+
+const printModInitDef = async (writer: WritableStreamDefaultWriter, encoder: TextEncoder, modInit: ACModInitDefInst) => {
+  await writer.write(encoder.encode(`void modinit__${modInit.modName}(AjisaiFuncFrame *parent_frame) {\n`));
+  await writer.write(encoder.encode("  static bool is_initialized = false;\n"));
+  await writer.write(encoder.encode("  if (!is_initialized) {\n"));
+
+  for (const inst of modInit.body) {
     await printFuncBodyInst(writer, encoder, inst);
   }
 
-  await writer.write(encoder.encode("  ajisai_mem_manager_deinit(&mem_manager);\n"));
+  await writer.write(encoder.encode("  is_initialized = true;\n"));
+  await writer.write(encoder.encode("  }\n"));
+
   await writer.write(encoder.encode("}\n"));
-};
+}
 
 const printFuncDef = async (writer: WritableStreamDefaultWriter, encoder: TextEncoder, def: ACDefInst) => {
   let headLine = `${toCType(def.resultType)} ${def.inst === "func.def" ? `userdef__${def.modName}_` : "closure"}_${def.funcName}(AjisaiFuncFrame *parent_frame`;

--- a/src/env.ts
+++ b/src/env.ts
@@ -20,10 +20,9 @@ export class VarEnv {
 
   private incrementTmpId(): number {
     switch (this.envKind) {
+      case "module":
       case "func":
         return this.#freshRootId++;
-      case "module":
-        throw new Error("module level environment doesn't have root table");
       case "let":
         return this.parent_!.incrementTmpId();
     }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -136,7 +136,7 @@ export class Parser {
       this.expect(")");
       return { tyKind: "primitive", name: "()" };
     } else {
-      if (this.eat("func")) {
+      if (this.eat("fn")) {
         this.expect("(");
 
         const argTypes: Type[] = [];
@@ -516,7 +516,7 @@ export class Parser {
       expr = this.parseIf();
     }
 
-    if (expr == null && this.eat("func")) {
+    if (expr == null && this.eat("fn")) {
       expr = this.parseFunc();
     }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -16,6 +16,7 @@ import {
   AstPathNode,
   AstModuleDeclareNode,
   AstImportNode,
+  AstExprStmtNode,
 } from "./ast.ts";
 import { Type, isPrimitiveTypeName } from "./type.ts";
 
@@ -64,11 +65,14 @@ export class Parser {
       } else if (this.eat("import")) {
         items.push(this.parseImport());
       } else {
-        throw new Error("invalid definition");
+        const expr = this.parseExpr();
+        this.expect(";");
+        const exprStmt: AstExprStmtNode = { nodeType: "exprStmt", expr };
+        items.push(exprStmt);
       }
     }
 
-    return { nodeType: "module", items };
+    return { nodeType: "module", items, envId: -1 };
   }
 
   private parseImport(): AstImportNode {

--- a/src/token.ts
+++ b/src/token.ts
@@ -3,7 +3,7 @@ export type TokenType =
   | "," | ":" | "::" | ";" | "|" | "(" | ")" | "{" | "}"
   | "->"
   | "true" | "false"
-  | "else" | "if" | "let" | "func" | "val" | "module" | "import"
+  | "else" | "if" | "let" | "fn" | "func" | "val" | "module" | "import"
   | "as"
   | "identifier" | "integer" | "string"
   | "eof";
@@ -20,6 +20,7 @@ const keywords = [
   "else",
   "if",
   "let",
+  "fn",
   "func",
   "val",
   "module",

--- a/src/type.ts
+++ b/src/type.ts
@@ -8,7 +8,7 @@ export const isPrimitiveTypeName = (s: string): PrimitiveTypeName | null => {
   return (primitiveTypeNames as Readonly<string[]>).includes(s) ? s as PrimitiveTypeName : null;
 };
 
-export type FuncKind = "userdef" | "closure" | "builtin";
+export type FuncKind = "userdef" | "closure" | "builtin" | "modinit";
 export type FuncType = { tyKind: "func", funcKind: FuncKind, argTypes: Type[], bodyType: Type };
 
 export type DummyType = { tyKind: "dummy" };

--- a/tests/parser_test.ts
+++ b/tests/parser_test.ts
@@ -204,6 +204,7 @@ Deno.test("parsing func definition test", () => {
     ast,
     {
       nodeType: "module",
+      envId: -1,
       items: [
         {
           nodeType: "def",
@@ -284,6 +285,7 @@ Deno.test("parsing empty main func test", () => {
     ast,
     {
       nodeType: "module",
+      envId: -1,
       items: [
         {
           nodeType: "def",
@@ -322,6 +324,7 @@ Deno.test("parsing func definition (with expression sequence) test", () => {
     ast,
     {
       nodeType: "module",
+      envId: -1,
       items: [
         {
           nodeType: "def",
@@ -523,6 +526,7 @@ Deno.test("parsing val definition test", () => {
     ast,
     {
       nodeType: "module",
+      envId: -1,
       items: [
         {
           nodeType: "def",
@@ -556,6 +560,7 @@ Deno.test("parsing empty main func (as val definition) test", () => {
     ast,
     {
       nodeType: "module",
+      envId: -1,
       items: [
         {
           nodeType: "def",
@@ -676,6 +681,7 @@ module deep_thought {
     ast,
     {
       nodeType: "module",
+      envId: -1,
       items: [
         {
           nodeType: "def",
@@ -684,6 +690,7 @@ module deep_thought {
             name: "deep_thought",
             mod: {
               nodeType: "module",
+              envId: -1,
               items: [
                 {
                   nodeType: "def",
@@ -743,6 +750,7 @@ import package as hello;
     ast,
     {
       nodeType: "module",
+      envId: -1,
       items: [
         {
           nodeType: "import",

--- a/tests/parser_test.ts
+++ b/tests/parser_test.ts
@@ -386,8 +386,8 @@ Deno.test("parsing func definition (with expression sequence) test", () => {
   );
 });
 
-Deno.test("parsing func expression test", () => {
-  const lexer = new Lexer("let val add = func(a: i32, b: i32) -> i32 { a + b } { add(1, 2) }");
+Deno.test("parsing fn expression test", () => {
+  const lexer = new Lexer("let val add = fn(a: i32, b: i32) -> i32 { a + b } { add(1, 2) }");
   const parser = new Parser(lexer, ".");
   const ast = parser.parseExpr();
 
@@ -440,8 +440,8 @@ Deno.test("parsing func expression test", () => {
   );
 });
 
-Deno.test("parsing func expression (without arguments) test", () => {
-  const lexer = new Lexer("let val hello = func() { println_str(\"Hello, world!\") } { hello() }");
+Deno.test("parsing fn expression (without arguments) test", () => {
+  const lexer = new Lexer("let val hello = fn() { println_str(\"Hello, world!\") } { hello() }");
   const parser = new Parser(lexer, ".");
   const ast = parser.parseExpr();
 
@@ -488,7 +488,7 @@ Deno.test("parsing func expression (without arguments) test", () => {
 });
 
 Deno.test("parsing immediately invoked function test", () => {
-  const lexer = new Lexer("func() { println_str(\"Hello, world!\") }()");
+  const lexer = new Lexer("fn() { println_str(\"Hello, world!\") }()");
   const parser = new Parser(lexer, ".");
   const ast = parser.parseExpr();
 
@@ -552,7 +552,7 @@ Deno.test("parsing val definition test", () => {
 });
 
 Deno.test("parsing empty main func (as val definition) test", () => {
-  const lexer = new Lexer("val main: func() = func() { () };");
+  const lexer = new Lexer("val main: fn() = fn() { () };");
   const parser = new Parser(lexer, ".");
   const ast = parser.parse().mod;
 


### PR DESCRIPTION
モジュールのトップレベルにおいて、関数以外の変数の定義文では、その変数を束縛する値に関して「コンパイル時に値が定まる」という制限を**持たない**仕様とする。つまり、値は実行時に動的に計算される。その仕様を実現するための前段階として、モジュールのトップレベルに式文を書ける言語機能を実装する。具体的な実装方法は、それらの式文をモジュールの初期化関数内に移動し、このモジュールが最初にインポートされたときに初期化関数を実行することで、式文の実行を実現する。今回は未実装だが、今後同じ初期化関数内で、モジュールのトップレベルの変数定義における右辺の式を計算して変数を初期化することになる。

これに伴い、モジュールの初期化式が実質的に main 関数の役割を果たすことができるので、main 関数の仕様を削除する。

また、関数定義文と関数式の先頭のキーワードが同じ `func` であったことで構文解析に支障があったので、関数式の先頭のキーワードは `fn` に変更した。また、関数の型の構文もこれに合わせて `func(<argument type>, ...) -> <return type>` から `fn(<argument type>, ...) -> <return type>` に変更した。