### PR TITLE
モジュールレベル変数

### DIFF
--- a/examples/submodule.ajs
+++ b/examples/submodule.ajs
@@ -5,16 +5,16 @@ module arith {
     func div(a: i32, b: i32) -> i32 { a / b }
 
     module deep_thought {
-        func answer() -> i32 { 42 }
+        val answer: i32 = 21 * 2;
     }
 }
 
 module a {
-    func hello() -> str { "hello1" }
+    val hello: str = "hello1";
     module a {
-        func hello() -> str { "hello2" }
+        val hello: str = "hello2";
         module a {
-            func hello() -> str { "hello3" }
+            val hello: str = "hello3";
         }
     }
 }
@@ -30,11 +30,11 @@ func main() {
     println_i32(arith::sub(10, 5));
     println_i32(arith::mul(10, 5));
     println_i32(arith::div(10, 5));
-    println_i32(deep_thought::answer());
+    println_i32(deep_thought::answer);
 
-    println_str(a1::hello());
-    println_str(a2::hello());
-    println_str(a3::hello());
+    println_str(a1::hello);
+    println_str(a2::hello);
+    println_str(a3::hello);
 }
 
 main();

--- a/src/acir.ts
+++ b/src/acir.ts
@@ -2,18 +2,19 @@ import { FuncKind, Type } from "./type.ts";
 
 export type ACModuleInst = {
   inst: "module",
-  funcDecls: ACDeclInst[],
+  decls: ACDeclInst[],
   funcDefs: ACDefInst[],
   modInits: ACModInitDefInst[],
   entryModName: string,
 };
 
-export type ACDeclInst = ACFuncDeclInst | ACClosureDeclInst;
+export type ACDeclInst = ACFuncDeclInst | ACClosureDeclInst | ACValDeclInst;
 export type ACDefInst = ACFuncDefInst | ACClosureDefInst;
 
 // export type ACEntryInst = { inst: "entry", body: ACFuncBodyInst[] };
-export type ACModInitBodyInst = ACFuncBodyInst | ACModInitInst;
+export type ACModInitBodyInst = ACFuncBodyInst | ACModInitInst | ACModValInitInst;
 export type ACModInitInst = { inst: "mod.init", modName: string };
+export type ACModValInitInst = { inst: "mod_val.init", varName: string, modName: string, value: ACPushValInst };
 export type ACModInitDefInst = { inst: "mod_init.def" , body: ACModInitBodyInst[], modName: string };
 
 export type ACFuncDeclInst = {
@@ -33,6 +34,8 @@ export type ACClosureDefInst = {
   envId: number,
   body: ACFuncBodyInst[]
 };
+
+export type ACValDeclInst = { inst: "val.decl", varName: string, ty: Type, modName: string };
 
 export type ACFuncBodyInst =
   ACRootTableInitInst | ACRootTableRegInst | ACRootTableUnregInst |

--- a/src/acir.ts
+++ b/src/acir.ts
@@ -1,20 +1,21 @@
 import { FuncKind, Type } from "./type.ts";
 
+export type ACEntryInst = { inst: "entry", entryMod: ACModuleInst, globalRootTableSize: number };
 export type ACModuleInst = {
   inst: "module",
   decls: ACDeclInst[],
   funcDefs: ACDefInst[],
   modInits: ACModInitDefInst[],
-  entryModName: string,
+  modName: string,
 };
 
 export type ACDeclInst = ACFuncDeclInst | ACClosureDeclInst | ACValDeclInst;
 export type ACDefInst = ACFuncDefInst | ACClosureDefInst;
 
-// export type ACEntryInst = { inst: "entry", body: ACFuncBodyInst[] };
-export type ACModInitBodyInst = ACFuncBodyInst | ACModInitInst | ACModValInitInst;
+export type ACModInitBodyInst = ACFuncBodyInst | ACModInitInst | ACModValInitInst | ACGlobalRootTableRegInst;
 export type ACModInitInst = { inst: "mod.init", modName: string };
 export type ACModValInitInst = { inst: "mod_val.init", varName: string, modName: string, value: ACPushValInst };
+export type ACGlobalRootTableRegInst = { inst: "global_root_table.reg", idx: number, varName: string, modName: string };
 export type ACModInitDefInst = { inst: "mod_init.def" , body: ACModInitBodyInst[], modName: string };
 
 export type ACFuncDeclInst = {

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -9,7 +9,7 @@ export type AstNode =
   | AstDeclareNode
   | AstExprNode;
 
-export type AstModuleNode = { nodeType: "module", items: AstModuleItemNode[], envId: number, rootTableSize?: number };
+export type AstModuleNode = { nodeType: "module", items: AstModuleItemNode[], envId: number, rootTableSize?: number, globalRootTableSize?: number };
 export type AstModuleItemNode = AstDefNode | AstImportNode | AstExprStmtNode;
 
 export type AstDefNode = { nodeType: "def", declare: AstDeclareNode | AstModuleDeclareNode };
@@ -47,7 +47,7 @@ export type AstFuncArgNode = { nodeType: "funcArg", name: string, ty?: Type };
 
 export type AstLetNode = { nodeType: "let", declares: AstDeclareNode[], body: AstExprSeqNode, bodyTy?: Type, envId: number, rootIdx?: number, rootIndices?: number[] };
 
-export type AstDeclareNode = { nodeType: "declare", name: string, ty?: Type, value: AstExprNode, modName?: string };
+export type AstDeclareNode = { nodeType: "declare", name: string, ty?: Type, value: AstExprNode, modName?: string, globalRootIdx?: number };
 
 export type AstIfNode = { nodeType: "if", cond: AstExprNode, then: AstExprSeqNode, else: AstExprSeqNode, ty?: Type };
 

--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -1,15 +1,16 @@
-import { ACClosureDeclInst, ACEntryInst } from "./acir.ts";
-import { ACFuncDeclInst } from "./acir.ts";
 import {
+  ACClosureDeclInst,
   ACClosureMakeInst,
-  ACModuleInst,
-  ACFuncBodyInst,
   ACDeclInst,
   ACDefInst,
+  ACEntryInst,
+  ACFuncBodyInst,
+  ACFuncDeclInst,
   ACFuncFrameDefTmpNoValInst,
-  ACPushValInst,
   ACModInitDefInst,
-  ACModInitBodyInst
+  ACModInitBodyInst,
+  ACModuleInst,
+  ACPushValInst
 } from "./acir.ts";
 
 import {


### PR DESCRIPTION
```
val hello: str = str_concat("Hello, ", "world!");
println_str(hello);
```

の `hello` のように、モジュールのレベルで変数を定義可能にする（グローバル変数）。変数の初期化式はそのモジュールをインポートする import 文が書かれているタイミングで、モジュール内の変数の定義順に評価される。

あるモジュールレベル変数から前方のモジュールレベル変数を参照することはできないなど、初期化式の評価順に基づく制限が存在する。