### PR TITLE
ローカル環境で定義した再帰関数の意味解析が通るようにする

### DIFF
--- a/examples/local_rec_func.ajs
+++ b/examples/local_rec_func.ajs
@@ -1,0 +1,9 @@
+let func fib(n: i32) -> i32 {
+    if n == 0 or n == 1 {
+        1
+    } else {
+        fib(n - 1) + fib(n - 2)
+    }
+} {
+    println_i32(fib(10))
+};


### PR DESCRIPTION
タイトル通り。ただし、ローカル環境で定義した再帰関数は自分自身を指す変数を自分の環境内にキャプチャするので、クロージャの変数捕捉を可能にしなければコンパイルできない。クロージャの変数捕捉は未実装なので現状はコンパイル不可。