### PR TITLE
モジュールレベルの関数定義周りの修正

### DIFF
--- a/examples/global_var_bound_by_func.ajs
+++ b/examples/global_var_bound_by_func.ajs
@@ -13,3 +13,24 @@ val sub: fn(i32, i32) -> i32 = make_closure2();
 
 println_i32(add(1, 2));
 println_i32(sub(1, 2));
+
+module A {
+    func hello1() {
+        println("hello! (1)")
+    }
+
+    val hello2: fn() = fn() {
+        println("hello! (2)")
+    };
+}
+
+import A;
+
+val hello1: fn() = A::hello1;
+hello1();
+
+val hello2: fn() = A::hello2;
+hello2();
+
+val println1: fn(str) = println;
+println1("hello! (3)");

--- a/examples/submodule.ajs
+++ b/examples/submodule.ajs
@@ -29,7 +29,9 @@ func main() {
     println_i32(arith::add(10, 5));
     println_i32(arith::sub(10, 5));
     println_i32(arith::mul(10, 5));
-    println_i32(arith::div(10, 5));
+    let val div = arith::div {
+        println_i32(div(10, 5))
+    };
     println_i32(deep_thought::answer);
 
     println(a1::hello);


### PR DESCRIPTION
以下の２つの問題を修正した：

- あるモジュールのモジュールレベルで定義した関数を、他のモジュールからインポートして変数束縛を行うと、その関数を参照する ACIR 命令 (`closure_make_static`) が誤ってインポート**した側**のモジュール名をその関数の属する（インポート**された側**の）モジュールとして指定してしまう問題
- モジュールのトップレベルで、他のモジュールレベル関数や組み込み関数が変数束縛を行うと、C ソースコードレベルでは変数と値の型の不一致が生じる問題（値側の変数の型は C の関数ポインタだが、それが束縛する変数の型は `AjisaiClosure *` となる）